### PR TITLE
Git checkout

### DIFF
--- a/Makefile_ccdb
+++ b/Makefile_ccdb
@@ -1,10 +1,25 @@
 ifdef CCDB_VERSION
-  CCDB_DIR = ccdb_$(CCDB_VERSION)
   TARFILE = ccdb_$(CCDB_VERSION)-src.tar.gz
   GET_SOURCE_TARGET = $(CCDB_DIR)/.untar_done
+  ifdef CCDB_DIRTAG
+    CCDB_DIR = ccdb_$(CCDB_VERSION)^$(CCDB_DIRTAG)
+  else
+    CCDB_DIR = ccdb_$(CCDB_VERSION)
+  endif
 else
   CCDB_DIR = ccdb
-  GET_SOURCE_TARGET = $(CCDB_DIR)/.checkout_done
+  GET_SOURCE_TARGET = $(CCDB_DIR)/.clone_done
+  ifndef CCDB_URL
+    CCDB_URL=https://github.com/JeffersonLab/ccdb
+  endif
+  ifdef CCDB_DIRTAG
+    CCDB_DIR = $(notdir $(CCDB_URL))^$(CCDB_DIRTAG)
+  else
+    CCDB_DIR = $(notdir $(CCDB_URL))
+  endif
+  ifndef CCDB_BRANCH
+    CCDB_BRANCH = master
+  endif
 endif
 
 all: prod_link
@@ -13,12 +28,15 @@ $(TARFILE):
 	wget --no-check-certificate https://halldweb.jlab.org/dist/$(TARFILE)
 
 $(CCDB_DIR)/.untar_done: $(TARFILE)
-	tar zxvf $(TARFILE)
+	rm -rfv untar_temp_dir
+	mkdir untar_temp_dir
+	cd untar_temp_dir ; tar zxf ../$(TARFILE)
+	mv -v untar_temp_dir/* $(CCDB_DIR)
+	rmdir -v untar_temp_dir
 	date > $@
 
-$(CCDB_DIR)/.checkout_done:
-	if [ -d $(CCDB_DIR) ] ; then svn cleanup $(CCDB_DIR) ; fi
-	svn checkout https://phys12svn.jlab.org/repos/trunk/ccdb
+$(CCDB_DIR)/.clone_done:
+	git clone -b $(CCDB_BRANCH) $(CCDB_URL) $(CCDB_DIR)
 	date > $@
 
 $(CCDB_DIR)/.untar_local_scons: $(GET_SOURCE_TARGET)

--- a/Makefile_hdds
+++ b/Makefile_hdds
@@ -20,14 +20,17 @@ ifdef HDDS_VERSION
  endif
  TARFILE = hdds-$(HDDS_VERSION)-src.tar.gz
 else
- SOURCE_CODE_TARGET = $(HDDS_HOME)/.checkout_done
+ SOURCE_CODE_TARGET = $(HDDS_HOME)/.clone_done
  ifndef HDDS_URL
-  HDDS_URL=https://halldsvn.jlab.org/repos/trunk/hdds
+  HDDS_URL=https://github.com/jeffersonlab/hdds
  endif
  ifdef HDDS_DIRTAG
   HDDS_DIR = $(notdir $(HDDS_URL))^$(HDDS_DIRTAG)
  else
   HDDS_DIR = $(notdir $(HDDS_URL))
+ endif
+ ifndef HDDS_BRANCH
+  HDDS_BRANCH = master
  endif
 endif
 
@@ -38,12 +41,8 @@ all: prod_link
 $(TARFILE):
 	wget --no-check-certificate http://halldweb.jlab.org/dist/$(TARFILE)
 
-$(HDDS_HOME)/.checkout_done:
-	rm -rf checkout_temp_dir
-	mkdir checkout_temp_dir
-	cd checkout_temp_dir ; svn co $(HDDS_URL)
-	mv -v checkout_temp_dir/* $(HDDS_DIR)
-	rmdir -v checkout_temp_dir
+$(HDDS_HOME)/.clone_done:
+	git clone -b $(HDDS_BRANCH) $(HDDS_URL) $(HDDS_DIR)
 	date > $@
 
 $(HDDS_HOME)/.untar_done: $(TARFILE)

--- a/Makefile_sim-recon
+++ b/Makefile_sim-recon
@@ -19,7 +19,7 @@ ifdef SIM_RECON_VERSION
  endif
  TARFILE = sim-recon-$(SIM_RECON_VERSION)-src.tar.gz
 else
- SOURCE_CODE_TARGET = $(HALLD_HOME)/.checkout_done
+ SOURCE_CODE_TARGET = $(HALLD_HOME)/.clone_done
  ifndef SIM_RECON_URL
   SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
  endif
@@ -47,7 +47,7 @@ $(HALLD_HOME)/.untar_done: $(TARFILE)
 	rmdir -v untar_temp_dir
 	date > $@
 
-$(HALLD_HOME)/.checkout_done:
+$(HALLD_HOME)/.clone_done:
 	git clone -b $(SIM_RECON_BRANCH) $(SIM_RECON_URL) $(SIM_RECON_DIR)
 	date > $@
 

--- a/Makefile_sim-recon
+++ b/Makefile_sim-recon
@@ -21,12 +21,15 @@ ifdef SIM_RECON_VERSION
 else
  SOURCE_CODE_TARGET = $(HALLD_HOME)/.checkout_done
  ifndef SIM_RECON_URL
-  SIM_RECON_URL=https://halldsvn.jlab.org/repos/trunk/sim-recon
+  SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
  endif
  ifdef SIM_RECON_DIRTAG
   SIM_RECON_DIR = $(notdir $(SIM_RECON_URL))^$(SIM_RECON_DIRTAG)
  else
   SIM_RECON_DIR = $(notdir $(SIM_RECON_URL))
+ endif
+ ifndef SIM_RECON_BRANCH
+  SIM_RECON_BRANCH = master
  endif
 endif
 export HALLD_HOME = $(PWD)/$(SIM_RECON_DIR)
@@ -45,11 +48,7 @@ $(HALLD_HOME)/.untar_done: $(TARFILE)
 	date > $@
 
 $(HALLD_HOME)/.checkout_done:
-	rm -rf checkout_temp_dir
-	mkdir checkout_temp_dir
-	cd checkout_temp_dir ; svn co $(SIM_RECON_URL)
-	mv -v checkout_temp_dir/* $(SIM_RECON_DIR)
-	rmdir -v checkout_temp_dir
+	git clone -o $(SIM_RECON_DIR) -b $(SIM_RECON_BRANCH) $(SIM_RECON_URL)
 	date > $@
 
 $(HALLD_HOME)/.getarg_patches_done: $(SOURCE_CODE_TARGET)

--- a/Makefile_sim-recon
+++ b/Makefile_sim-recon
@@ -48,7 +48,7 @@ $(HALLD_HOME)/.untar_done: $(TARFILE)
 	date > $@
 
 $(HALLD_HOME)/.checkout_done:
-	git clone -o $(SIM_RECON_DIR) -b $(SIM_RECON_BRANCH) $(SIM_RECON_URL)
+	git clone -b $(SIM_RECON_BRANCH) $(SIM_RECON_URL) $(SIM_RECON_DIR)
 	date > $@
 
 $(HALLD_HOME)/.getarg_patches_done: $(SOURCE_CODE_TARGET)


### PR DESCRIPTION
These changes allow sim-recon, hdds, and ccdb to get the code from an arbitrary Git repository with the default repository being that of the jeffersonlab organization at GitHub. If a version number is specified in the environment, the traditional tarball route is taken. If not then a url variable and branch variable are consulted with default repo as mentioned above and default branch = master. 