### PR TITLE
Add JANA_RESOURCE_DIR to environment at JLab

### DIFF
--- a/gluex_env_clean.csh
+++ b/gluex_env_clean.csh
@@ -33,14 +33,12 @@ unsetenv CLHEP_INCLUDE
 unsetenv HDDS_HOME
 unsetenv HALLD_HOME
 unsetenv HALLD_MY
-unsetenv SIM_RECON_DIRTAG
-unsetenv SIM_RECON_VERSION
-unsetenv SIM_RECON_URL
 unsetenv BMS_OSNAME
 unsetenv JANA_HOME
 unsetenv JANA_CALIB_URL
 unsetenv JANA_GEOMETRY_URL
 unsetenv JANA_PLUGIN_PATH
+unsetenv JANA_RESOURCE_DIR
 unsetenv CCDB_HOME
 unsetenv AMPTOOLS_HOME
 unsetenv AMPTOOLS
@@ -51,6 +49,7 @@ unsetenv CCDB_CONNECTION
 unsetenv CCDB_USER
 unsetenv EVIOROOT
 # versions
+unsetenv SIM_RECON_VERSION
 unsetenv JANA_VERSION
 unsetenv HDDS_VERSION
 unsetenv CERNLIB_VERSION
@@ -59,7 +58,8 @@ unsetenv CLHEP_VERSION
 unsetenv ROOT_VERSION
 unsetenv CCDB_VERSION
 unsetenv EVIO_VERSION
-# directory tags
+# urls for checkout
+unsetenv SIM_RECON_URL
 unsetenv JANA_URL
 unsetenv HDDS_URL
 unsetenv CERNLIB_URL
@@ -68,7 +68,8 @@ unsetenv CLHEP_URL
 unsetenv ROOT_URL
 unsetenv CCDB_URL
 unsetenv EVIO_URL
-# urls for checkout
+# directory tags
+unsetenv SIM_RECON_DIRTAG
 unsetenv JANA_DIRTAG
 unsetenv HDDS_DIRTAG
 unsetenv CERNLIB_DIRTAG

--- a/gluex_env_clean.sh
+++ b/gluex_env_clean.sh
@@ -39,6 +39,7 @@ unset JANA_HOME
 unset JANA_CALIB_URL
 unset JANA_GEOMETRY_URL
 unset JANA_PLUGIN_PATH
+unset JANA_RESOURCE_DIR
 unset CCDB_HOME
 unset AMPTOOLS_HOME
 unset AMPTOOLS
@@ -49,6 +50,7 @@ unset EVIOROOT
 unset CCDB_CONNECTION
 unset CCDB_USER
 # versions
+unset SIM_RECON_VERSION
 unset JANA_VERSION
 unset HDDS_VERSION
 unset CERNLIB_VERSION
@@ -57,7 +59,8 @@ unset CLHEP_VERSION
 unset ROOT_VERSION
 unset CCDB_VERSION
 unset EVIO_VERSION
-# directory tags
+# urls for checkout
+unset SIM_RECON_URL
 unset JANA_URL
 unset HDDS_URL
 unset CERNLIB_URL
@@ -66,7 +69,8 @@ unset CLHEP_URL
 unset ROOT_URL
 unset CCDB_URL
 unset EVIO_URL
-# urls for checkout
+# directory tags
+unset SIM_RECON_DIRTAG
 unset JANA_DIRTAG
 unset HDDS_DIRTAG
 unset CERNLIB_DIRTAG

--- a/gluex_env_jlab.csh
+++ b/gluex_env_jlab.csh
@@ -6,6 +6,7 @@ setenv GLUEX_TOP /group/halld/Software/builds/$BMS_OSNAME
 # finish the rest of the gluex environment
 source $BUILD_SCRIPTS/gluex_env_version.csh $VERSION_XML
 setenv JANA_CALIB_URL $CCDB_CONNECTION
+setenv JANA_RESOURCE_DIR /group/halld/www/halldweb/html/resources
 # python on the cue
 setenv PATH /apps/python/PRO/bin:$PATH
 setenv LD_LIBRARY_PATH /apps/python/PRO/lib:$LD_LIBRARY_PATH

--- a/gluex_env_jlab.sh
+++ b/gluex_env_jlab.sh
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/bash
 VERSION_XML=/group/halld/www/halldweb/html/dist/version.xml
 export BUILD_SCRIPTS=/group/halld/Software/build_scripts
 export BMS_OSNAME=`$BUILD_SCRIPTS/osrelease.pl`
@@ -6,6 +6,9 @@ export GLUEX_TOP=/group/halld/Software/builds/$BMS_OSNAME
 # finish the rest of the environment
 . $BUILD_SCRIPTS/gluex_env_version.sh $VERSION_XML
 export JANA_CALIB_URL=$CCDB_CONNECTION
+export JANA_RESOURCE_DIR=/group/halld/www/halldweb/html/resources
 # python on the cue
+echo path before = $PATH
 export PATH=/apps/python/PRO/bin:$PATH
+echo path after = $PATH
 export LD_LIBRARY_PATH=/apps/python/PRO/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Have it point to /group/halld/www/halldweb/html/resource.

modified:   gluex_env_clean.csh
  clean JANA_RESOURCE_DIR for tcsh
modified:   gluex_env_clean.sh
  clean JANA_RESOURCE_DIR for bash
  clean SIM_RECON_VERSION, URL, DIRTAG (should have been there before)
modified:   gluex_env_jlab.csh
  define JANA_RESOURCE_DIR for tcsh
modified:   gluex_env_jlab.sh
  define JANA_RESOURCE_DIR for bash