### PR TITLE
If the build directory already exists, then delete it.

### DIFF
--- a/pull_request/build_pull_request.sh
+++ b/pull_request/build_pull_request.sh
@@ -20,7 +20,7 @@ export SIM_RECON_SCONS_OPTIONS="-j8 SHOWBUILD=1"
 # make sim-recon
 rm -fv $logfile
 if [ -d "sim-recon^$branch" ]; then
-    rm -r sim-recon^$branch
+    rm -rf sim-recon^$branch
 fi
 make -f $BUILD_SCRIPTS/Makefile_sim-recon >& $logfile
 build_exit_code=$?

--- a/pull_request/build_pull_request.sh
+++ b/pull_request/build_pull_request.sh
@@ -19,6 +19,9 @@ export SIM_RECON_DIRTAG=$branch
 export SIM_RECON_SCONS_OPTIONS="-j8 SHOWBUILD=1"
 # make sim-recon
 rm -fv $logfile
+if [ -d "sim-recon^$branch" ]; then
+    rm -r sim-recon^$branch
+fi
 make -f $BUILD_SCRIPTS/Makefile_sim-recon >& $logfile
 build_exit_code=$?
 mv -v $logfile sim-recon^$branch


### PR DESCRIPTION
This is especially useful if we want to rebuild if the PR branch changes.