### PR TITLE
Fixes for checking and handling PRs from multiple repositories

### DIFF
--- a/pull_request/build_pull_request.sh
+++ b/pull_request/build_pull_request.sh
@@ -14,7 +14,18 @@ echo === warning: using hard-wired location of build_scripts for development ===
 export BUILD_SCRIPTS=/home/gluex/build_scripts # for development only
 ############################################
 unset SIM_RECON_VERSION
-export SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
+if [ -z "$SIM_RECON_URL" ]; then
+    export SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
+fi
+# only run tests from the main JLab repo, not forked repos for security
+if [ "$SIM_RECON_URL" != https://github.com/jeffersonlab/sim-recon ]; then
+    # create notice where the build log would be
+    if [ ! -d "sim-recon^$branch" ]; then
+       mkdir "sim-recon^$branch"
+    fi
+    echo "Tests are not run on pull requests from forked repositories." > sim-recon^$
+    exit 1
+fi
 export SIM_RECON_BRANCH=$branch_git
 export SIM_RECON_DIRTAG=$branch
 export SIM_RECON_SCONS_OPTIONS="-j8 SHOWBUILD=1"

--- a/pull_request/build_pull_request.sh
+++ b/pull_request/build_pull_request.sh
@@ -14,9 +14,7 @@ echo === warning: using hard-wired location of build_scripts for development ===
 export BUILD_SCRIPTS=/home/gluex/build_scripts # for development only
 ############################################
 unset SIM_RECON_VERSION
-if [ -z "$SIM_RECON_URL" ]; then
-    export SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
-fi
+export SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
 export SIM_RECON_BRANCH=$branch_git
 export SIM_RECON_DIRTAG=$branch
 export SIM_RECON_SCONS_OPTIONS="-j8 SHOWBUILD=1"

--- a/pull_request/build_pull_request.sh
+++ b/pull_request/build_pull_request.sh
@@ -15,15 +15,17 @@ export BUILD_SCRIPTS=/home/gluex/build_scripts # for development only
 ############################################
 unset SIM_RECON_VERSION
 if [ -z "$SIM_RECON_URL" ]; then
-    export SIM_RECON_URL=https://github.com/jeffersonlab/sim-recon
+    export SIM_RECON_URL=https://github.com/JeffersonLab/sim-recon
 fi
 # only run tests from the main JLab repo, not forked repos for security
-if [ "$SIM_RECON_URL" != https://github.com/jeffersonlab/sim-recon ]; then
+echo COMPARE "$SIM_RECON_URL"
+echo TO "https://github.com/JeffersonLab/sim-recon"
+if [ "$SIM_RECON_URL" != "https://github.com/JeffersonLab/sim-recon" ]; then
     # create notice where the build log would be
     if [ ! -d "sim-recon^$branch" ]; then
        mkdir "sim-recon^$branch"
     fi
-    echo "Tests are not run on pull requests from forked repositories." > sim-recon^$
+    echo "Tests are not run on pull requests from forked repositories." > "sim-recon^$branch/$logfile"
     exit 1
 fi
 export SIM_RECON_BRANCH=$branch_git

--- a/pull_request/build_pull_request_service.sh
+++ b/pull_request/build_pull_request_service.sh
@@ -2,9 +2,6 @@
 branch_git=$1
 comment_url=$2
 branch=$(echo $branch_git | sed -r 's/\//_/g')
-if [ ! -z "$3" ]; then
-    export SIM_RECON_URL=$3
-fi
 echo build_pull_request_service.sh: building branch $branch
 report_file=report_${branch}.txt
 export BUILD_SCRIPTS=/home/gluex/build_scripts
@@ -12,8 +9,7 @@ echo build_pull_request_service.sh: using BUILD_SCRIPTS = $BUILD_SCRIPTS
 command="$BUILD_SCRIPTS/pull_request/build_pull_request.sh $branch_git"
 echo build_pull_request_service.sh: executing $command
 $command
-if [ $? -eq 0 ]
-then
+if [ $? -eq 0 ]; then
     status="SUCCESS"
 else
     status="FAILURE"
@@ -26,13 +22,12 @@ echo build_pull_request_service.sh: create $report_file
 $BUILD_SCRIPTS/pull_request/build_pull_request_report.sh make_${branch}.log > $report_file
 if [ $status == "SUCCESS" ]; then
     # test for runtime errors and get overall status
-    command="bash $BUILD_SCRIPTS/pull_request/test_pull_request.sh $branch"
+    command="$BUILD_SCRIPTS/pull_request/test_pull_request.sh $branch"
     echo build_pull_request_service.sh: executing $command
-    $command >& $build_dir/tests/summary.txt
+    $command
     echo "Failure list" > $build_dir/tests/failures.txt
     grep -i 'failed' $build_dir/tests/summary.txt >> $build_dir/tests/failures.txt
-    if [ $? -ne 0 ]
-    then
+    if [ $? -ne 0 ]; then
         test_status="SUCCESS"
         failure_comment=""
     else
@@ -41,25 +36,24 @@ if [ $status == "SUCCESS" ]; then
     fi
     # create test status comment
     read -r -d '' comment << EOM
-    Test status for this pull request: ${test_status}\n \
-    \n \
-    $failure_comment
-    Summary: [$build_dir/tests/summary.txt](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/tests/summary.txt)\n \
-    Logs: [$build_dir/tests/log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/tests/log)\n
-    \n \
-    Build log: [$build_dir/make_${branch}.log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/make_${branch}.log)\n \
-    Build report: [$build_dir/$report_file](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/$report_file)\n \
-    Location of build: $build_dir\n
-    EOM
+Test status for this pull request: ${test_status}\n \
+\n $failure_comment \
+Summary: [$build_dir/tests/summary.txt](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/tests/summary.txt)\n \
+Logs: [$build_dir/tests/log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/tests/log)\n \
+\n \
+Build log: [$build_dir/make_${branch}.log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/make_${branch}.log)\n \
+Build report: [$build_dir/$report_file](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/$report_file)\n \
+Location of build: $build_dir\n
+EOM
 else
     # create build status comment
     read -r -d '' comment << EOM
-    Build status for this pull request: ${status}\n \
-    \n \
-    Build log: [$build_dir/make_${branch}.log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/make_${branch}.log)\n \
-    Build report: [$build_dir/$report_file](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/$report_file)\n \
-    Location of build: $build_dir\n
-    EOM
+Build status for this pull request: ${status}\n \
+\n \
+Build log: [$build_dir/make_${branch}.log](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/make_${branch}.log)\n \
+Build report: [$build_dir/$report_file](https://halldweb.jlab.org/pull_request_test/sim-recon^$branch/$report_file)\n \
+Location of build: $build_dir\n
+EOM
 fi
 # leave comment on github
 export PYTHONPATH=/home/gluex/lib/python2.7/site-packages

--- a/pull_request/build_pull_request_service.sh
+++ b/pull_request/build_pull_request_service.sh
@@ -2,6 +2,9 @@
 branch_git=$1
 comment_url=$2
 branch=$(echo $branch_git | sed -r 's/\//_/g')
+if [ ! -z "$3" ]; then
+    export SIM_RECON_URL=$3
+fi
 echo build_pull_request_service.sh: building branch $branch
 report_file=report_${branch}.txt
 export BUILD_SCRIPTS=/home/gluex/build_scripts

--- a/pull_request/build_pull_request_service_sshwrapper.sh
+++ b/pull_request/build_pull_request_service_sshwrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 branch=$(echo $1 | sed -r 's/\//_/g')
 export BUILD_SCRIPTS=/home/gluex/build_scripts
-nohup $BUILD_SCRIPTS/pull_request/build_pull_request_service.sh $1 $2 >/work/halld/pull_request_test/ssh_log^$branch 2>&1 &
+nohup $BUILD_SCRIPTS/pull_request/build_pull_request_service.sh $1 $2 $3 >/work/halld/pull_request_test/ssh_log^$branch 2>&1 &

--- a/pull_request/build_pull_request_service_sshwrapper.sh
+++ b/pull_request/build_pull_request_service_sshwrapper.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+branch=$(echo $1 | sed -r 's/\//_/g')
 export BUILD_SCRIPTS=/home/gluex/build_scripts
-nohup $BUILD_SCRIPTS/pull_request/build_pull_request_service.sh $1 $2 $3 >/work/halld/pull_request_test/ssh_log^$1 2>&1 &
+nohup $BUILD_SCRIPTS/pull_request/build_pull_request_service.sh $1 $2 >/work/halld/pull_request_test/ssh_log^$branch 2>&1 &

--- a/pull_request/build_sim-recon_wehook.py
+++ b/pull_request/build_sim-recon_wehook.py
@@ -53,12 +53,15 @@ class Root(object):
             # this is a little paranoid, but better safe...
             branch_name_cleaned = branch_name.replace('"', '\\"')
             branch_name_cleaned.replace("'", "\\'")
+            # get the URL of the git repo, to support forked repos
+            # probably should clean this URL too..
+            repo_url = data["pull_request"]["base"]["repo"]["html_url"]
 
             # launch the test build
             # we use a single-command ssh key to launch the build on the ifarm
-            cmd = "env -u SSH_AUTH_SOCK ssh -i /home/marki/.ssh/id_dsa_pull_request gluex@ifarm1102 %s %s"%(branch_name_cleaned,pull_request_comment_url)
+            cmd = "env -u SSH_AUTH_SOCK ssh -i /home/marki/.ssh/id_dsa_pull_request gluex@ifarm1102 %s %s %s"%(branch_name_cleaned,pull_request_comment_url,repo_url)
             subprocess.Popen(cmd, shell=True)
-            return "Test build for branch %s launched successfully!"%branch_name_cleaned 
+            return "Test build for branch %s from repository %s launched successfully!"%(branch_name_cleaned,repo_url)
         else:
             return "Ignoring this callback."
 

--- a/pull_request/build_sim-recon_wehook.py
+++ b/pull_request/build_sim-recon_wehook.py
@@ -53,15 +53,12 @@ class Root(object):
             # this is a little paranoid, but better safe...
             branch_name_cleaned = branch_name.replace('"', '\\"')
             branch_name_cleaned.replace("'", "\\'")
-            # get the URL of the git repo, to support forked repos
-            # probably should clean this URL too..
-            repo_url = data["pull_request"]["base"]["repo"]["html_url"]
 
             # launch the test build
             # we use a single-command ssh key to launch the build on the ifarm
-            cmd = "env -u SSH_AUTH_SOCK ssh -i /home/marki/.ssh/id_dsa_pull_request gluex@ifarm1102 %s %s %s"%(branch_name_cleaned,pull_request_comment_url,repo_url)
+            cmd = "env -u SSH_AUTH_SOCK ssh -i /home/marki/.ssh/id_dsa_pull_request gluex@ifarm1102 %s %s"%(branch_name_cleaned,pull_request_comment_url)
             subprocess.Popen(cmd, shell=True)
-            return "Test build for branch %s from repository %s launched successfully!"%(branch_name_cleaned,repo_url) 
+            return "Test build for branch %s launched successfully!"%branch_name_cleaned 
         else:
             return "Ignoring this callback."
 


### PR DESCRIPTION
This adds in hooks to the pull request testing for checking to see which repository a PR comes from, and intelligently responding to it.  For now, we only run tests if the PR is from the main JLab repo.