### PR TITLE
PR tests: Update determination of test status

### DIFF
--- a/pull_request/build_pull_request_service.sh
+++ b/pull_request/build_pull_request_service.sh
@@ -19,8 +19,7 @@ else
 fi
 build_dir=/work/halld/pull_request_test/sim-recon^$branch
 web_dir=/work/halld2/pull_request_test/sim-recon^$branch
-mkdir -p $web_dir
-pushd $build_dir
+rm -rf $web_dir && mkdir -p $web_dir
 cd $build_dir
 rm -f $report_file
 echo build_pull_request_service.sh: create $report_file
@@ -39,7 +38,6 @@ if [ $status == "SUCCESS" ]; then
     # Check if the hdgeant test failed and use in overall status
     grep 'hdgeant failed' $build_dir/tests/summary.txt >> $build_dir/tests/failures.txt
     code2=$?
-    # Check if the hdgeant test failed and use in overall status
     if [ $code -ne 0 ]; then
         code=$code2
     fi

--- a/pull_request/build_pull_request_service.sh
+++ b/pull_request/build_pull_request_service.sh
@@ -38,8 +38,10 @@ if [ $status == "SUCCESS" ]; then
     code=$?
     # Check if the hdgeant test failed and use in overall status
     grep 'hdgeant failed' $build_dir/tests/summary.txt >> $build_dir/tests/failures.txt
+    code2=$?
+    # Check if the hdgeant test failed and use in overall status
     if [ $code -ne 0 ]; then
-        code=$?
+        code=$code2
     fi
     if [ $code -ne 0 ]; then
         test_status="SUCCESS"

--- a/pull_request/test_pull_request.sh
+++ b/pull_request/test_pull_request.sh
@@ -3,7 +3,6 @@
 # nonzero exit code signals runtime error or mistake in env. setup
 # EVIO: path to evio file to process
 # plugins.txt: list of plugins to test
-initial_dir=$(pwd)
 # farm-specific set-up - from gluex_env_jlab.sh
 BUILD_SCRIPTS=/group/halld/Software/build_scripts
 osrelease=$(perl $BUILD_SCRIPTS/osrelease.pl)
@@ -16,7 +15,8 @@ if [[ $osrelease == *CentOS6* || $osrelease == *RHEL6* ]]
 fi
 branch=$1
 target_dir=/work/halld/pull_request_test/sim-recon^$branch/tests
-rm -rf $target_dir; mkdir $target_dir; cd $target_dir
+rm -rf $target_dir && mkdir $target_dir
+pushd $target_dir
 cp $BUILD_SCRIPTS/pull_request/plugins.txt .
 cp $BUILD_SCRIPTS/pull_request/control.in .
 LOG=log; mkdir $LOG
@@ -62,4 +62,4 @@ elif [ $code -ne 0 ]; then
 else
     echo "hdgeant passed."
 fi >> summary.txt
-cd $initial_dir
+popd

--- a/pull_request/test_pull_request.sh
+++ b/pull_request/test_pull_request.sh
@@ -30,10 +30,11 @@ echo "Test summary" > summary.txt
 for plugin in $(cat plugins.txt); do
     echo -e "\nTesting $plugin ..." >> summary.txt
     timeout $TLIMIT hd_root -PNTHREADS=$THREADS -PEVENTS_TO_KEEP=$EVENTS $EVIO -PPLUGINS=$plugin >& $LOG/$plugin.txt
-    if [ $? -eq 124 ]; then
+    code=$?
+    if [ $code -eq 124 ]; then
         echo "$plugin plugin failed with $TLIMIT seconds timeout (status=124)."
-    elif [ $? -ne 0 ]; then
-        echo "$plugin plugin failed with exit status $?."
+    elif [ $code -ne 0 ]; then
+        echo "$plugin plugin failed with exit status $code."
     else
         echo "$plugin plugin passed."
     fi >> summary.txt
@@ -42,20 +43,22 @@ function join { local IFS="$1"; shift; echo "$*"; }
 plugins=$(join , $(cat plugins.txt))
 echo -e "\nTesting all listed plugins at the same time ..." >> summary.txt
 timeout $TLIMIT hd_root -PNTHREADS=$THREADS -PEVENTS_TO_KEEP=$EVENTS $EVIO -PPLUGINS=$plugins >& $LOG/multiple_plugins.txt
-if [ $? -eq 124 ]; then
+code=$?
+if [ $code -eq 124 ]; then
     echo "Multiple-plugins test failed with $TLIMIT seconds timeout (status=124)."
-elif [ $? -ne 0 ]; then
-    echo "Multiple-plugins test failed with exit status $?."
+elif [ $code -ne 0 ]; then
+    echo "Multiple-plugins test failed with exit status $code."
 else
     echo "Multiple-plugins test passed."
 fi >> summary.txt
 echo -e "\nTesting hdgeant ..." >> summary.txt
 export JANA_CALIB_CONTEXT="variation=mc_sim1"
 timeout $TLIMIT hdgeant >& $LOG/hdgeant.txt
-if [ $? -eq 124 ]; then
+code=$?
+if [ $code -eq 124 ]; then
     echo "hdgeant failed with $TLIMIT seconds timeout (status=124)."
-elif [ $? -ne 0 ]; then
-    echo "hdgeant failed with exit status $?."
+elif [ $code -ne 0 ]; then
+    echo "hdgeant failed with exit status $code."
 else
     echo "hdgeant passed."
 fi >> summary.txt


### PR DESCRIPTION
1. Attempt to minimize # of failures arising from environment.
   Don't use individual test results when forming overall status.
   Just use the results of the multiple-plugins and hdgeant test.
2. Print the exit status code when a test fails and indicate if
   the test timed out.

Also, test with a newer input file, from run 030858.