### PR TITLE
added support for osx10.12

### DIFF
--- a/osrelease.pl
+++ b/osrelease.pl
@@ -108,6 +108,8 @@ if ($uname eq 'Linux') {
         $release = '_macosx10.10';
     } elsif ($release_string =~ /^15.*/) {
         $release = '_macosx10.11';
+    } elsif ($release_string =~ /^16.*/) {
+        $release = '_macosx10.12';
 	} else {
 	    print STDERR "unrecognized Mac OS X (Darwin) release\n";
 	    $release = '_macosx';


### PR DESCRIPTION
This avoids the error:

unrecognized Mac OS X (Darwin) release

for users of Mac OS Sierra
