### PR TITLE
Use absolute paths for gluex_env_jlab.(c)sh.

### DIFF
--- a/gluex_env_nightly.csh
+++ b/gluex_env_nightly.csh
@@ -1,4 +1,4 @@
 #!/bin/tcsh
 setenv BUILD_DATE $1
 setenv BMS_OSNAME `/group/halld/Software/build_scripts/osrelease.pl`
-source gluex_env_jlab.csh /u/scratch/gluex/nightly/$BUILD_DATE/$BMS_OSNAME/version_$BUILD_DATE.xml
+source /group/halld/Software/build_scripts/gluex_env_jlab.csh /u/scratch/gluex/nightly/$BUILD_DATE/$BMS_OSNAME/version_$BUILD_DATE.xml

--- a/gluex_env_nightly.sh
+++ b/gluex_env_nightly.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 BUILD_DATE=$1
 export BMS_OSNAME=`/group/halld/Software/build_scripts/osrelease.pl`
-source gluex_env_jlab.sh /u/scratch/gluex/nightly/$BUILD_DATE/$BMS_OSNAME/version_$BUILD_DATE.xml
+source /group/halld/Software/build_scripts/gluex_env_jlab.sh /u/scratch/gluex/nightly/$BUILD_DATE/$BMS_OSNAME/version_$BUILD_DATE.xml


### PR DESCRIPTION
Testing of the previous version was probably done in the build_scripts directory itself. Not good.