### PR TITLE
Use gluex-built python for RHEL6 and CentOS6 at JLab.

### DIFF
--- a/gluex_env_jlab.csh
+++ b/gluex_env_jlab.csh
@@ -18,8 +18,9 @@ if ( $BMS_OSNAME =~ *CentOS6* || $BMS_OSNAME =~ *RHEL6* ) then
     setenv LD_LIBRARY_PATH ${GCC_HOME}/lib64:${GCC_HOME}/lib
     setenv BMS_OSNAME `$BUILD_SCRIPTS/osrelease.pl`
     # python on the cue
-    setenv PATH $BUILD_SCRIPTS/patches/jlab_extras/rh6:/apps/python/PRO/bin:$PATH
-    setenv LD_LIBRARY_PATH /apps/python/PRO/lib:$LD_LIBRARY_PATH
+    set pypath=/group/halld/Software/builds/$BMS_OSNAME/python/Python-2.7.13
+    setenv PATH $pypath/bin:$PATH
+    setenv LD_LIBRARY_PATH $pypath/lib:$LD_LIBRARY_PATH
 endif
 setenv GLUEX_TOP /group/halld/Software/builds/$BMS_OSNAME
 # perl on the cue

--- a/gluex_env_jlab.sh
+++ b/gluex_env_jlab.sh
@@ -23,8 +23,9 @@ if [[ $BMS_OSNAME == *CentOS6* || $BMS_OSNAME == *RHEL6* ]]
     export LD_LIBRARY_PATH=${GCC_HOME}/lib64:${GCC_HOME}/lib
     export BMS_OSNAME=`$BUILD_SCRIPTS/osrelease.pl`
     # python on the cue
-    export PATH=$BUILD_SCRIPTS/patches/jlab_extras/rh6:/apps/python/PRO/bin:$PATH
-    export LD_LIBRARY_PATH=/apps/python/PRO/lib:$LD_LIBRARY_PATH
+    pypath=/group/halld/Software/builds/$BMS_OSNAME/python/Python-2.7.13
+    export PATH=$pypath:$PATH
+    export LD_LIBRARY_PATH=$pypath/lib:$LD_LIBRARY_PATH
 fi
 export GLUEX_TOP=/group/halld/Software/builds/$BMS_OSNAME
 # perl on the cue


### PR DESCRIPTION
On RHEL6 and CentOS6 at JLab, use a gluex-built version of python. See https://groups.google.com/forum/#!topic/gluex-software/1VmYx2QZex0 for discussion of the issue.