### PR TITLE
Explicitly name the output tar file in the wget command. This seems to

### DIFF
--- a/Makefile_amptools
+++ b/Makefile_amptools
@@ -13,7 +13,7 @@ AMPTOOLS_PACKAGES = AmpTools AmpPlotter
 all: prod_link
 
 $(TARFILE):
-	wget https://github.com/mashephe/AmpTools/archive/$(TARFILE)
+	wget https://github.com/mashephe/AmpTools/archive/$(TARFILE) -O $(TARFILE)
 
 $(AMPTOOLS_DIR)/.unpack: $(TARFILE)
 	rm -rfv untar_temp


### PR DESCRIPTION
change. There is no tar.gz extension on ifarm1101 (CentOS6) for
unknown reasons.