### PR TITLE
Define additional environment variables.

### DIFF
--- a/version.pl
+++ b/version.pl
@@ -96,12 +96,12 @@ foreach $href (@b) {
 		}
 		$package_home_dir = "$gluex_top/$name/$this_dir_prefix$version$sep$dirtag$dir_suffix{$name}";
 	    }
-	    if ($dirtag) {print_command("${name_in_caps}_DIRTAG", $dirtag);}
-	    if ($url) {print_command("${name_in_caps}_URL", $url);}
-	    if ($branch) {print_command("${name_in_caps}_BRANCH", $branch);}
-	    if ($hash) {print_command("${name_in_caps}_HASH", $hash);}
 	}
 	print_command($package_home_var, $package_home_dir);
+	if ($dirtag) {print_command("${name_in_caps}_DIRTAG", $dirtag);}
+	if ($url) {print_command("${name_in_caps}_URL", $url);}
+	if ($branch) {print_command("${name_in_caps}_BRANCH", $branch);}
+	if ($hash) {print_command("${name_in_caps}_HASH", $hash);}
     }
 }
 


### PR DESCRIPTION
Define environment variables for dirtag, url, branch, and hash if they are XML attributes of a package even if the home attribute is defined. Before the home attribute would block definition in the environment for these attributes.
