### PR TITLE
Speed up environment set-up

### DIFF
--- a/gluex_env.csh
+++ b/gluex_env.csh
@@ -42,7 +42,7 @@ if ($status) setenv PATH $CERN_ROOT/bin:$PATH
 # Geant4
 if (! $?G4ROOT) setenv G4ROOT $GLUEX_TOP/geant4/prod
 if ( -e $G4ROOT) then
-    set g4setup=`find $G4ROOT/share/ -name geant4make.csh`
+    set g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.csh`
     if ( -f $g4setup) then
 	set g4dir=`dirname $g4setup`
 	source $g4setup $g4dir

--- a/gluex_env.sh
+++ b/gluex_env.sh
@@ -73,7 +73,7 @@ fi
 if [ -z "$G4ROOT" ]; then export G4ROOT=$GLUEX_TOP/geant4/prod; fi
 if [ -e "$G4ROOT" ]
     then
-    g4setup=`find $G4ROOT/share/ -name geant4make.sh`
+    g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.sh`
     if [ -f "$g4setup" ]; then source $g4setup; fi
     unset g4setup
 fi


### PR DESCRIPTION
When looking for G4 native set-up file, only look three directory levels down from $G4ROOT/share. This speeds up global set-up by significant amount (more than 5x).
