### PR TITLE
Patch sbms.py for RHEL6 and CentOS6 at JLab

### DIFF
--- a/Makefile_sim-recon
+++ b/Makefile_sim-recon
@@ -10,6 +10,7 @@
 # will be checked out from the repos/trunk.
 
 PWD = $(shell pwd)
+JLAB6 = $(shell $(BUILD_SCRIPTS)/jlab6.sh)
 ifdef SIM_RECON_VERSION
  SOURCE_CODE_TARGET = $(HALLD_HOME)/.untar_done
  ifdef SIM_RECON_DIRTAG
@@ -54,14 +55,18 @@ ifdef SIM_RECON_HASH
 endif
 	date > $@
 
-$(HALLD_HOME)/.getarg_patches_done: $(SOURCE_CODE_TARGET)
+$(HALLD_HOME)/.patches_done: $(SOURCE_CODE_TARGET)
 ifdef APPLY_GETARG_PATCH
 	cp -pv $(BUILD_SCRIPTS)/patches/getarg_fix/* \
 		$(HALLD_HOME)/src/programs/Simulation/HDGeant
 endif
+ifeq ($(JLAB6),true)
+	cd $(HALLD_HOME)/src/SBMS ; \
+	patch sbms.py < $(BUILD_SCRIPTS)/patches/sim-recon/sbms.py.patch
+endif
 	date > $@
 
-$(HALLD_HOME)/.sconstruct_done: $(HALLD_HOME)/.getarg_patches_done
+$(HALLD_HOME)/.sconstruct_done: $(HALLD_HOME)/.patches_done
 	cd $(HALLD_HOME)/src ; scons install $(SIM_RECON_SCONS_OPTIONS)
 	date > $@
 

--- a/patches/sim-recon/sbms.py.patch
+++ b/patches/sim-recon/sbms.py.patch
@@ -1,0 +1,11 @@
+--- sbms.py.old	2018-02-05 13:38:20.741702319 -0500
++++ sbms.py.new	2018-02-05 13:37:45.057513071 -0500
+@@ -643,7 +643,7 @@
+         SQLITECPP_LIBPATH = ["%s/lib" % (sqlitecpp_home)]
+         env.AppendUnique(LIBPATH = SQLITECPP_LIBPATH)
+         env.AppendUnique(LIBS    = 'SQLiteCpp')
+-	AddSQLite.SQLITE_LINKFLAGS= "-lsqlite3"
++	AddSQLite.SQLITE_LINKFLAGS= "-lsqlite3 -Wl,-rpath=/apps/sqlite/sqlite-3.13.0/lib"
+ 	AddLinkFlags(env, AddSQLite.SQLITE_LINKFLAGS)
+ 
+ 


### PR DESCRIPTION
Insert rpath switch to pick up non-standard sqlite library.