### PR TITLE
cntr tag in bmsosname

### DIFF
--- a/osrelease.pl
+++ b/osrelease.pl
@@ -202,7 +202,7 @@ if ($processor eq 'unknown') {
 # container tag
 $container_tag = "";
 	if (-d "/.singularity.d") {
-	    $container_tag = "-sing";
+	    $container_tag = "-cntr";
 	}
 
 # Finally, form and print the complete string to stdout

--- a/osrelease.pl
+++ b/osrelease.pl
@@ -199,6 +199,12 @@ if ($processor eq 'unknown') {
 	chomp $processor;
 }
 
+# container tag
+$container_tag = "";
+	if (-d "/.singularity.d") {
+	    $container_tag = "-sing";
+	}
+
 # Finally, form and print the complete string to stdout
-print "${uname}${release}-${processor}-${compiler_version}\n";
+print "${uname}${release}-${processor}-${compiler_version}${container_tag}\n";
 exit;


### PR DESCRIPTION
add "-cntr" to the end of BMS_OSNAME when inside a Singularity container. In the future, this addition should be done for Docker as well, but that is not implemented yet.
