### PR TITLE
Get the source tar file from JLab. Only works for version 10.02.p02.

### DIFF
--- a/Makefile_geant4
+++ b/Makefile_geant4
@@ -15,7 +15,13 @@ endif
 all: $(G4DIR)/.make_install_done
 
 $(TARFILE):
-	wget http://geant4.web.cern.ch/geant4/support/source/$(TARFILE)
+# The following is a kludge prompted by
+# a) we need to have version 10.02.p02 presently.
+# b) G4 folks have changed the distribution system so that a working tar file
+#    for this version does not exist.
+# So for now we will get an old version of the tar file from JLab
+#	wget http://geant4.web.cern.ch/geant4/support/source/$(TARFILE)
+	wget https://halldweb.jlab.org/dist/$(TARFILE)
 
 $(G4DIR)/.untar_done: $(TARFILE)
 	tar zxf $(TARFILE)


### PR DESCRIPTION
This is a kludge prompted by
a) we need to have version 10.02.p02 presently.
b) G4 folks have changed the distribution system so that a working tar file for this version does not exist.
So for now we will get an old version of the tar file from JLab
