### PR TITLE
Fix logic for setting MCWRAPPER_CENTRAL

### DIFF
--- a/gluex_env.csh
+++ b/gluex_env.csh
@@ -122,7 +122,7 @@ if (! $?HD_UTILITIES_HOME) setenv HD_UTILITIES_HOME $GLUEX_TOP/hd_utilities/prod
 #
 # gluex_MCwrapper
 #
-if (! $?MCWRAPPER_CENTRAL) setenv MCWRAPPER_CENTRAL $GLUEX_TOP/gluex_MCwrapper/prod
+if (! $?MCWRAPPER_CENTRAL) setenv MCWRAPPER_CENTRAL $HD_UTILITIES_HOME/MCwrapper
 setenv PATH ${MCWRAPPER_CENTRAL}:$PATH
 #
 # gluex_root_analysis

--- a/gluex_env.sh
+++ b/gluex_env.sh
@@ -161,7 +161,7 @@ if [ -z "$HD_UTILITIES_HOME" ]; then export HD_UTILITIES_HOME=$GLUEX_TOP/hd_util
 #
 # gluex_MCwrapper
 #
-if [ -z "$MCWRAPPER_CENTRAL" ]; then export MCWRAPPER_CENTRAL=$GLUEX_TOP/hd_utilities/prod; fi
+if [ -z "$MCWRAPPER_CENTRAL" ]; then export MCWRAPPER_CENTRAL=$HD_UTILITIES_HOME/MCwrapper; fi
 export PATH=${MCWRAPPER_CENTRAL}:$PATH
 #
 # gluex_root_analysis


### PR DESCRIPTION
when it is not defined in advance. Presumeably that happens when the stand-alone repository is
_not_ used.