### PR TITLE
Shell commands to help set-up gluex software at JLab.

### DIFF
--- a/gluex_boot_jlab.csh
+++ b/gluex_boot_jlab.csh
@@ -1,0 +1,6 @@
+if (! $?BUILD_SCRIPTS) setenv BUILD_SCRIPTS /group/halld/Software/build_scripts
+setenv DIST /group/halld/www/halldweb/html/dist
+alias gxenv "source $BUILD_SCRIPTS/gluex_env_clean.csh; setenv BUILD_SCRIPTS $BUILD_SCRIPTS; source $BUILD_SCRIPTS/gluex_env_jlab.csh \!*"
+alias gxclean "source $BUILD_SCRIPTS/gluex_env_clean.csh"
+echo $PATH | grep $BUILD_SCRIPTS > /dev/null
+if ($status) setenv PATH ${BUILD_SCRIPTS}:$PATH

--- a/gluex_boot_jlab.sh
+++ b/gluex_boot_jlab.sh
@@ -1,0 +1,13 @@
+if [ -z "$BUILD_SCRIPTS" ]
+    then export BUILD_SCRIPTS=/group/halld/Software/build_scripts
+fi
+export DIST=/group/halld/www/halldweb/html/dist
+function gxenv() { bs_save=$BUILD_SCRIPTS; \
+    source $BUILD_SCRIPTS/gluex_env_clean.sh; \
+    export BUILD_SCRIPTS=$bs_save; \
+    source $BUILD_SCRIPTS/gluex_env_jlab.sh $1; \
+    unset bs_save; }
+function gxclean() { source $BUILD_SCRIPTS/gluex_env_clean.sh; }
+if [ `echo $PATH | grep -c $BUILD_SCRIPTS` -eq 0 ]
+    then export PATH=$BUILD_SCRIPTS:$PATH
+fi


### PR DESCRIPTION
These will set-up aliases (tcsh) or functions (bash) to facilitate setting up the GlueX shell environment, namely gxenv and gxclean.