### PR TITLE
Install lapack libraries a second time.

### DIFF
--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -37,6 +37,9 @@ endif
 	mkdir -p 2005/src/lib
 	install $(LAPACK_HOME)/liblapack.a 2005/src/lib/liblapack.a
 	install $(LAPACK_HOME)/librefblas.a 2005/src/lib/libblas.a
+	mkdir -p 2005/lib
+	install $(LAPACK_HOME)/liblapack.a 2005/lib/liblapack3.a
+	install $(LAPACK_HOME)/librefblas.a 2005/lib/libblas.a
 	date > $@
 
 .build_done: .install_lapack_done


### PR DESCRIPTION
The first was used for building cernlib, the second to allow others to link to lapack.