### PR TITLE
CERNLIB build on GCC7+

### DIFF
--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -27,12 +27,12 @@ $(DIST_FILES):
 ifdef DEBUG
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_cernlib.debug.patch
 endif
+	sed '/SAVE/d' 2005/src/geant321/miface/gmicap.F > 2005/src/geant321/miface/gmicap.F ; \
 	cd 2005/src/packlib/kuip/kuip ; \
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/kstring.h.patch
 	cd 2005/src/config ; \
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch	
-	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch
-	cd 2005/src/geant321/miface ; sed '/SAVE/d' gmicap.F > gmicap.F
+	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch	
 	date > $@
 
 .install_lapack_done: .patch_done

--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -31,8 +31,8 @@ endif
 	cd 2005/src/packlib/kuip/kuip ; \
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/kstring.h.patch
 	cd 2005/src/config ; \
-	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch	
-	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch	
+	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch
+	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch
 	date > $@
 
 .install_lapack_done: .patch_done

--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -30,10 +30,9 @@ endif
 	cd 2005/src/packlib/kuip/kuip ; \
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/kstring.h.patch
 	cd 2005/src/config ; \
-	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch
-	cd 2005/src/geant321/miface ; \
-	sed '/SAVE/d' gmicap.F > gmicap.F
+	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch	
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch
+	cd 2005/src/geant321/miface ; sed '/SAVE/d' gmicap.F > gmicap.F
 	date > $@
 
 .install_lapack_done: .patch_done

--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -31,6 +31,8 @@ endif
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/kstring.h.patch
 	cd 2005/src/config ; \
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/Imake.cf.patch
+	cd 2005/src/geant321/miface ; \
+	sed '/SAVE/d' gmicap.F > gmicap.F
 	patch < $(BUILD_SCRIPTS)/patches/cernlib/Install_old_patchy4.patch
 	date > $@
 


### PR DESCRIPTION
Mark, 
The patch removes a line from geant3 with `SAVE` word. 

Here is more explanation why it is needed and why it is OK to do so

https://github.com/alisw/alidist/issues/1345 