### PR TITLE
get tar files from github, not from cern

### DIFF
--- a/Makefile_geant4
+++ b/Makefile_geant4
@@ -1,8 +1,11 @@
-ifndef G4_VERSION
-    G4_VERSION = 10.02.p02
+ifndef GEANT4_VERSION
+    GEANT4_VERSION = 10.02.p02
 endif
-TARFILE = geant4.$(G4_VERSION).tar.gz
-G4DIR = geant4.$(G4_VERSION)
+MAJOR_VERSION = $(shell echo $(GEANT4_VERSION) | awk -F. '{print $$1}')
+MINOR_VERSION = $(shell echo $(GEANT4_VERSION) | awk -F. '{print $$2}' | sed 's/^0*//')
+SUBMINOR_VERSION = $(shell echo $(GEANT4_VERSION) | awk -F. '{print $$3}' | sed 's/p//' | sed 's/^0*//')
+TARFILE = v$(MAJOR_VERSION).$(MINOR_VERSION).$(SUBMINOR_VERSION).tar.gz
+G4DIR = geant4.$(GEANT4_VERSION)
 
 which_cmake3 := $(shell which cmake3)
 find_cmake3 := $(findstring cmake3, $(which_cmake3))
@@ -15,16 +18,11 @@ endif
 all: $(G4DIR)/.make_install_done
 
 $(TARFILE):
-# The following is a kludge prompted by
-# a) we need to have version 10.02.p02 presently.
-# b) G4 folks have changed the distribution system so that a working tar file
-#    for this version does not exist.
-# So for now we will get an old version of the tar file from JLab
-#	wget --no-verbose http://geant4.web.cern.ch/geant4/support/source/$(TARFILE)
-	wget --no-verbose https://halldweb.jlab.org/dist/$(TARFILE)
+	wget --no-verbose http://github.com/Geant4/geant4/archive/$(TARFILE)
 
 $(G4DIR)/.untar_done: $(TARFILE)
 	tar zxf $(TARFILE)
+	mv -v geant4-$(MAJOR_VERSION).$(MINOR_VERSION).$(SUBMINOR_VERSION) $(G4DIR)
 	date > $@
 
 $(G4DIR)/.patch_done: $(G4DIR)/.untar_done
@@ -66,3 +64,6 @@ help:
 	@echo CMAKE = $(CMAKE)
 	@echo G4DIR = $(G4DIR)
 	@echo TARFILE = $(TARFILE)
+	@echo MAJOR_VERSION = /$(MAJOR_VERSION)/
+	@echo MINOR_VERSION = /$(MINOR_VERSION)/
+	@echo SUBMINOR_VERSION = /$(SUBMINOR_VERSION)/


### PR DESCRIPTION
Removes the kludge that required downloading tar files from JLab because of their absence at CERN. GitHub has all of the sub-minor versions available.