### PR TITLE
Python chooser no adjustment centos8 fedora33 rebase

### DIFF
--- a/Makefile_cernlib_Vogt
+++ b/Makefile_cernlib_Vogt
@@ -37,6 +37,9 @@ endif
 ifeq ($(GCC_GE_10), true)
 	cd 2005/src/config ; \
 	patch linux-lp64.cf < $(BUILD_SCRIPTS)/patches/cernlib/linux-lp64.cf.patch
+	cd 2005/src/packlib/cspack/sysreq ; patch serror.c < $(BUILD_SCRIPTS)/patches/cernlib/serror.c.patch
+	cd 2005/src/packlib/cspack/sysreq ; patch socket.c < $(BUILD_SCRIPTS)/patches/cernlib/socket.c.patch
+	cd 2005/src/packlib/kernlib/kernbit/z268 ; patch systems.c < $(BUILD_SCRIPTS)/patches/cernlib/systems.c.patch
 endif
 ifeq ($(GCC_GE_9), true)
 	patch 2005/src/pawlib/paw/fmotif/Imakefile < $(BUILD_SCRIPTS)/patches/cernlib/Imakefile_fmotif.patch

--- a/Makefile_halld_recon
+++ b/Makefile_halld_recon
@@ -26,6 +26,7 @@ else ifeq ($(HALLD_RECON_DEBUG_LEVEL), 2)
  override HALLD_RECON_SCONS_OPTIONS += DEBUG=1 OPTIMIZATION=0
 endif
 export HALLD_RECON_HOME = $(PWD)/$(HALLD_RECON_DIR)
+PYTHON = $(shell $(BUILD_SCRIPTS)/python_chooser.sh command)
 SCONS = $(shell $(BUILD_SCRIPTS)/python_chooser.sh scons)
 PYVERSION = $(shell $(BUILD_SCRIPTS)/python_chooser.sh version)
 
@@ -63,7 +64,7 @@ endif
 	date > $@
 
 $(HALLD_RECON_HOME)/.sconstruct_done: $(HALLD_RECON_HOME)/.patches_done
-	cd $(HALLD_RECON_HOME)/src ; $(SCONS) install $(HALLD_RECON_SCONS_OPTIONS)
+	cd $(HALLD_RECON_HOME)/src ; $(SCONS) install PYTHONCOMMAND=$(PYTHON) $(HALLD_RECON_SCONS_OPTIONS)
 	date > $@
 
 ifndef GVMS_TEST

--- a/Makefile_halld_recon
+++ b/Makefile_halld_recon
@@ -62,14 +62,7 @@ ifdef APPLY_GETARG_PATCH
 endif
 	date > $@
 
-$(HALLD_RECON_HOME)/.python_adjustment: $(HALLD_RECON_HOME)/.patches_done
-ifeq ($(PYVERSION), 3)
-	cd $(HALLD_RECON_HOME)/src/SBMS ; $(RM) sbms.py ; ln -s sbms3.py sbms.py
-	cd $(HALLD_RECON_HOME)/src ; $(RM) SConstruct ; ln -s SConstruct3 SConstruct
-endif
-	date > $@
-
-$(HALLD_RECON_HOME)/.sconstruct_done: $(HALLD_RECON_HOME)/.python_adjustment
+$(HALLD_RECON_HOME)/.sconstruct_done: $(HALLD_RECON_HOME)/.patches_done
 	cd $(HALLD_RECON_HOME)/src ; $(SCONS) install $(HALLD_RECON_SCONS_OPTIONS)
 	date > $@
 

--- a/Makefile_halld_sim
+++ b/Makefile_halld_sim
@@ -27,6 +27,7 @@ else ifeq ($(HALLD_SIM_DEBUG_LEVEL), 2)
 endif
 export HALLD_SIM_HOME = $(PWD)/$(HALLD_SIM_DIR)
 SCONS = $(shell $(BUILD_SCRIPTS)/python_chooser.sh scons)
+PYTHONCONFIG = $(shell $(BUILD_SCRIPTS)/python_chooser.sh config)
 PYVERSION = $(shell $(BUILD_SCRIPTS)/python_chooser.sh version)
 
 all: $(HALLD_SIM_HOME)/halld_sim_prereqs_version.xml
@@ -57,7 +58,7 @@ endif
 	date > $@
 
 $(HALLD_SIM_HOME)/.sconstruct_done: $(HALLD_SIM_HOME)/.patches_done
-	cd $(HALLD_SIM_HOME)/src ; $(SCONS) install $(HALLD_SIM_SCONS_OPTIONS)
+	cd $(HALLD_SIM_HOME)/src ; $(SCONS) install PYTHONCONFIG=$(PYTHONCONFIG) $(HALLD_SIM_SCONS_OPTIONS)
 	date > $@
 
 ifndef GVMS_TEST

--- a/Makefile_halld_sim
+++ b/Makefile_halld_sim
@@ -56,14 +56,7 @@ ifdef APPLY_GETARG_PATCH
 endif
 	date > $@
 
-$(HALLD_SIM_HOME)/.python_adjustment: $(HALLD_SIM_HOME)/.patches_done
-ifeq ($(PYVERSION), 3)
-	cd $(HALLD_SIM_HOME)/src/SBMS ; $(RM) sbms.py ; ln -s sbms3.py sbms.py
-	cd $(HALLD_SIM_HOME)/src ; $(RM) SConstruct ; ln -s SConstruct3 SConstruct
-endif
-	date > $@
-
-$(HALLD_SIM_HOME)/.sconstruct_done: $(HALLD_SIM_HOME)/.python_adjustment
+$(HALLD_SIM_HOME)/.sconstruct_done: $(HALLD_SIM_HOME)/.patches_done
 	cd $(HALLD_SIM_HOME)/src ; $(SCONS) install $(HALLD_SIM_SCONS_OPTIONS)
 	date > $@
 

--- a/Makefile_hdds
+++ b/Makefile_hdds
@@ -66,13 +66,7 @@ $(HDDS_HOME)/.untar_done: $(TARFILE)
 	rmdir -v untar_temp_dir
 	date > $@
 
-$(HDDS_HOME)/.python_adjustment: $(SOURCE_CODE_TARGET)
-ifeq ($(PYVERSION), 3)
-	cd $(HDDS_HOME) ; $(RM) SConstruct ; ln -s SConstruct3 SConstruct
-endif
-	date > $@
-
-$(HDDS_HOME)/.sconstruct_done: $(HDDS_HOME)/.python_adjustment
+$(HDDS_HOME)/.sconstruct_done: $(SOURCE_CODE_TARGET)
 	cd $(HDDS_HOME) ; $(SCONS) install $(HDDS_SCONS_OPTIONS)
 	date > $@
 

--- a/Makefile_hdgeant4
+++ b/Makefile_hdgeant4
@@ -26,6 +26,8 @@ else
 endif
 
 HDGEANT4_HOME = $(PWD)/$(HDGEANT4_DIR)
+PYTHON_CONFIG = $(shell $(BUILD_SCRIPTS)/python_chooser.sh config)
+PYTHON_BOOST = $(shell $(BUILD_SCRIPTS)/python_chooser.sh boost)
 
 all: force_rebuild_action $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml
 
@@ -54,18 +56,18 @@ $(HDGEANT4_HOME)/.untar_done: $(TARFILE)
 	date > $@
 
 $(HDGEANT4_HOME)/.link_to_fixes_done: $(SOURCE_CODE_TARGET)
-	test -d $(HDGEANT4_HOME)/src/G4.$(GEANT4_VERSION)fixes || (echo G4fixes directory does not exist. GEANT4_VERSION must be defined. GEANT4_VERSION = $(GEANT4_VERSION) ; exit 1)
+	@test -d $(HDGEANT4_HOME)/src/G4.$(GEANT4_VERSION)fixes || (echo G4fixes directory does not exist. GEANT4_VERSION must be defined. GEANT4_VERSION = $(GEANT4_VERSION) ; exit 1)
 	cd $(HDGEANT4_HOME)/src ; ln -s G4.$(GEANT4_VERSION)fixes G4fixes 
 	date > $@
 
 $(HDGEANT4_HOME)/.make_done: $(HDGEANT4_HOME)/.link_to_fixes_done
-	@cd $(HDGEANT4_HOME) ; \
+	cd $(HDGEANT4_HOME) ; \
 	if [ -z "$$G4SYSTEM" ] ; \
 	    then echo Geant4 setup not complete, sourcing geant4make.sh ; \
 	    . `find $(G4ROOT)/share/ -name geant4make.sh` ; \
 	fi ; \
 	echo executing make ; \
-	make $(HDGEANT4_MAKE_OPTIONS)
+	make PYTHON_CONFIG=$(PYTHON_CONFIG) BOOST_PYTHON_LIB=$(PYTHON_BOOST) $(HDGEANT4_MAKE_OPTIONS)
 	date > $@
 
 $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml: $(HDGEANT4_HOME)/.make_done

--- a/Makefile_hdgeant4
+++ b/Makefile_hdgeant4
@@ -28,6 +28,7 @@ endif
 HDGEANT4_HOME = $(PWD)/$(HDGEANT4_DIR)
 PYTHON_CONFIG = $(shell $(BUILD_SCRIPTS)/python_chooser.sh config)
 PYTHON_BOOST = $(shell $(BUILD_SCRIPTS)/python_chooser.sh boost)
+PYTHON_LIB_OPTION = $(shell $(BUILD_SCRIPTS)/python_chooser.sh lib)
 
 all: force_rebuild_action $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml
 
@@ -67,7 +68,7 @@ $(HDGEANT4_HOME)/.make_done: $(HDGEANT4_HOME)/.link_to_fixes_done
 	    . `find $(G4ROOT)/share/ -name geant4make.sh` ; \
 	fi ; \
 	echo executing make ; \
-	make PYTHON_CONFIG=$(PYTHON_CONFIG) BOOST_PYTHON_LIB=$(PYTHON_BOOST) $(HDGEANT4_MAKE_OPTIONS)
+	make PYTHON_CONFIG=$(PYTHON_CONFIG) BOOST_PYTHON_LIB=$(PYTHON_BOOST) PYTHON_LIB_OPTION=$(PYTHON_LIB_OPTION) $(HDGEANT4_MAKE_OPTIONS)
 	date > $@
 
 $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml: $(HDGEANT4_HOME)/.make_done

--- a/Makefile_jana
+++ b/Makefile_jana
@@ -48,8 +48,7 @@ ifeq ($(PYVERSION), 3)
 	@echo info: applying patches
 	patch $(JANA_HOME)/SBMS/sbms.py \
 	    < $(BUILD_SCRIPTS)/patches/jana/sbms.py.patch
-	patch $(JANA_HOME)/SBMS/sbms_config.py \
-	    < $(BUILD_SCRIPTS)/patches/jana/sbms_config.py.patch
+	futurize -w $(JANA_HOME)/SBMS/sbms_config.py
 	patch $(JANA_HOME)/SConstruct \
 	    < $(BUILD_SCRIPTS)/patches/jana/SConstruct.patch
 else

--- a/Makefile_jana
+++ b/Makefile_jana
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 PWD = $(shell pwd)
 
 ifdef JANA_VERSION
@@ -51,7 +52,6 @@ $(JANA_HOME)/.checkout_done:
 	date > $@
 
 $(JANA_HOME)/.patches_done: $(JANA_HOME)/.untar_done
-#	@echo info: PYTHON_GE_3 = $(PYTHON_GE_3)
 ifeq ($(PYVERSION), 3)
 	@echo info: applying patches
 	patch $(JANA_HOME)/SBMS/sbms.py \

--- a/Makefile_jana
+++ b/Makefile_jana
@@ -8,6 +8,9 @@ ifdef JANA_VERSION
   JANA_DIR = jana_$(JANA_VERSION)
  endif
  TARFILE = jana_$(JANA_VERSION).tgz
+ VERSION_MAJOR = $(shell echo $(JANA_VERSION) | awk -F. '{print $$1}')
+ VERSION_MINOR = $(shell echo $(JANA_VERSION) | awk -F. '{print $$2}')
+ VERSION_GE_08 = $(shell if [[ $(VERSION_MAJOR) -eq 0 && $(VERSION_MINOR) -ge 8 ]]; then echo true; else echo false; fi)
 else
  SOURCE_CODE_TARGET = $(JANA_HOME)/.checkout_done
  ifndef JANA_URL
@@ -21,6 +24,11 @@ else
 endif
 SCONS = $(shell $(BUILD_SCRIPTS)/python_chooser.sh scons)
 PYVERSION = $(shell $(BUILD_SCRIPTS)/python_chooser.sh version)
+ifeq ($(VERSION_GE_08), true)
+ SBMS_CONFIG_PATCH = sbms_config.py.082.patch
+else
+ SBMS_CONFIG_PATCH = sbms_config.py.patch
+endif
 
 export JANA_HOME = $(PWD)/$(JANA_DIR)
 
@@ -48,7 +56,8 @@ ifeq ($(PYVERSION), 3)
 	@echo info: applying patches
 	patch $(JANA_HOME)/SBMS/sbms.py \
 	    < $(BUILD_SCRIPTS)/patches/jana/sbms.py.patch
-	futurize -w $(JANA_HOME)/SBMS/sbms_config.py
+	patch $(JANA_HOME)/SBMS/sbms_config.py \
+	    < $(BUILD_SCRIPTS)/patches/jana/$(SBMS_CONFIG_PATCH)
 	patch $(JANA_HOME)/SConstruct \
 	    < $(BUILD_SCRIPTS)/patches/jana/SConstruct.patch
 else
@@ -71,3 +80,7 @@ $(TARFILE):
 show_env:
 	@echo PYTHON_MAJOR_VERSION = $(PYTHON_MAJOR_VERSION)
 	@echo PYTHON_GE_3 = $(PYTHON_GE_3)
+	@echo VERSION_MAJOR = $(VERSION_MAJOR)
+	@echo VERSION_MINOR = $(VERSION_MINOR)
+	@echo VERSION_GE_08 = $(VERSION_GE_08)
+	@echo SBMS_CONFIG_PATCH = $(SBMS_CONFIG_PATCH)

--- a/patches/cernlib/serror.c.patch
+++ b/patches/cernlib/serror.c.patch
@@ -1,0 +1,22 @@
+--- serror.c.original	2020-11-01 16:38:40.207541766 -0500
++++ serror.c.fixed	2020-11-01 16:41:24.189302848 -0500
+@@ -176,15 +176,19 @@
+         }
+         else {
+ #if !defined(vms)
++/*
+                 if ((n>0) && (n<sys_nerr)) {
+                         return((char*)sys_errlist[n]);
+                 }
+                 else {
++*/
+                         (void) sprintf(buf,"%s: %d\n",
+  sys_serrlist[SEMAXERR+1-SEBASEOFF],
+                             n);
+                         return(buf);
++/*
+                 }
++*/
+ #else /* vms */
+ /*
+  * There are (were) some bugs is DEC C compilers (/OPT), just check

--- a/patches/cernlib/socket.c.patch
+++ b/patches/cernlib/socket.c.patch
@@ -1,0 +1,13 @@
+--- /home/marki/Desktop/socket.c.original	2020-11-01 17:22:02.392620683 -0500
++++ /home/marki/Desktop/socket.c.fixed	2020-11-01 17:37:12.446629643 -0500
+@@ -415,7 +415,10 @@
+ s_errmsg()                              /* return last error message    */
+ {
+ #if !defined(vms)
++/*
+         return((char*)sys_errlist[errno]);
++*/
++        return((char*)sys_serrlist[errno]);
+ #else /* vms */
+ #if defined(MULTINET) && (MULTINET == 1)
+         return(vms_errno_string());

--- a/patches/cernlib/systems.c.patch
+++ b/patches/cernlib/systems.c.patch
@@ -1,0 +1,20 @@
+--- systems.c.original	2020-11-01 17:57:19.636331673 -0500
++++ systems.c.fixed	2020-11-01 19:10:37.929602329 -0500
+@@ -131,7 +131,7 @@
+ #endif /* hpux */
+ 
+ 	if ( (ps=(FILE *)popen(command,"r"))==NULL ) {
+-		fprintf(stderr,"systems(): popen(): %s\n",sys_errlist[errno] );
++		fprintf(stderr,"systems(): popen(): %s\n",strerror(errno) );
+ 		*rc= -errno;
+ 		*chars=0        ;
+                 *l=0        ;
+@@ -141,7 +141,7 @@
+ 	rcode = fread(buf, 1, buflen , ps );
+ 	if ( rcode < 0 ) {
+ 		fprintf(stderr,"systems(): pipe fread(): %s\n",
+-                                                       sys_errlist[errno] );
++                                                       strerror(errno) );
+ 		buf[0]='\n';
+ 		*rc= -errno;
+                 *chars=0        ;

--- a/patches/jana/sbms_config.py.082.patch
+++ b/patches/jana/sbms_config.py.082.patch
@@ -1,0 +1,39 @@
+--- sbms_config.py.original	2020-10-21 16:56:45.153504000 -0400
++++ sbms_config.py.patched	2020-10-21 16:57:46.512910600 -0400
+@@ -55,7 +55,7 @@
+ 	ofdirname = '%s/JANA' % env['variant_dir']
+ 	ofdir = '%s' % env.Dir(ofdirname)
+ 	ofname = '%s/jana_config.h' % ofdir
+-	print 'sbms : Making jana_config.h in %s' % ofdir
++	print('sbms : Making jana_config.h in %s' % ofdir)
+ 	
+ 	# ROOT
+ 	HAVE_ROOT = 0
+@@ -92,12 +92,12 @@
+ 
+ 	# If showing build, print config. results
+ 	if(env['SHOWBUILD']>0):
+-		print '--- Configuration results ----'
+-		print '    HAVE_ROOT = %d' % HAVE_ROOT
+-		print '  HAVE_XERCES = %d' % HAVE_XERCES
+-		print '      XERCES3 = %d' % XERCES3
+-		print '    HAVE_CCDB = %d' % HAVE_CCDB
+-		print '------------------------------'
++		print('--- Configuration results ----')
++		print('    HAVE_ROOT = %d' % HAVE_ROOT)
++		print('  HAVE_XERCES = %d' % HAVE_XERCES)
++		print('      XERCES3 = %d' % XERCES3)
++		print('    HAVE_CCDB = %d' % HAVE_CCDB)
++		print('------------------------------')
+ 		
+ 	str = ''
+ 	
+@@ -147,7 +147,7 @@
+ 	ofdir = '%s' % env.Dir(ofdirname)
+ 	ofname = '%s/jana-config' % ofdir
+ 
+-	print 'sbms : Making jana-config in %s' % ofdir
++	print('sbms : Making jana-config in %s' % ofdir)
+ 	
+ 	# ROOT
+ 	HAVE_ROOT = 0

--- a/python_chooser.sh
+++ b/python_chooser.sh
@@ -57,14 +57,29 @@ distribution=$dist_name$dist_version
 ## start with old versions and work your way up
 #
 declare -A pycommand
+pycommand[lib]=''
 if [ $dist_name == Fedora ]
 then
-    pycommand[command]=python
-    pycommand[config]=python-config
-    pycommand[scons]=scons
-    get_python_version
-    pycommand[version]=$version_major
-    pycommand[boost]=boost_python
+    if [ $dist_version -ge 32 ]
+    then
+	pycommand[command]=python
+	pycommand[config]=python-config
+	pycommand[scons]=scons
+	get_python_version
+	pycommand[version]=$version_major
+	pycommand[boost]=boost_python$version_major$version_minor
+    else
+	pycommand[command]=python
+	pycommand[config]=python-config
+	pycommand[scons]=scons
+	get_python_version
+	pycommand[version]=$version_major
+	pycommand[boost]=boost_python
+    fi
+    if  [ $dist_version -ge 33 ]
+    then
+	pycommand[lib]=-lpython$version_major.$version_minor
+    fi
 elif [[ $dist_name == RedHat || $dist_name == CentOS ]]
 then
     if [ $dist_version -le 7 ]
@@ -125,6 +140,10 @@ case $arg in
 	echo scons command = ${pycommand[scons]}
 	echo version command = ${pycommand[version]}
 	echo boost command = ${pycommand[boost]}
+	echo lib command = ${pycommand[lib]}
+	;;
+    lib)
+	echo ${pycommand[lib]}
 	;;
     scons)
 	echo ${pycommand[scons]}

--- a/python_chooser.sh
+++ b/python_chooser.sh
@@ -82,6 +82,13 @@ then
 	pycommand[boost]=boost_python$version_major
     fi
     pycommand[version]=$version_major
+elif [ $dist_name == Ubuntu ]
+then
+    pycommand[command]=python
+    get_python_version
+    pycommand[config]=python-config
+    pycommand[scons]=scons
+    pycommand[boost]=boost_python
 fi
 #
 # report the answer

--- a/python_chooser.sh
+++ b/python_chooser.sh
@@ -84,10 +84,18 @@ then
     pycommand[version]=$version_major
 elif [ $dist_name == Ubuntu ]
 then
+    pycommand[command]=python3
+    get_python_version
+    pycommand[config]=python-config
+    pycommand[scons]=scons
+    pycommand[version]=$version_major
+    pycommand[boost]=boost_python
+else
     pycommand[command]=python
     get_python_version
     pycommand[config]=python-config
     pycommand[scons]=scons
+    pycommand[version]=$version_major
     pycommand[boost]=boost_python
 fi
 #

--- a/python_chooser.sh
+++ b/python_chooser.sh
@@ -4,13 +4,23 @@
 # correct python-related command to use
 #
 ## accepts one positional argument
-## argument can have one of three values: command, config, or scons
+## argument can have one of four values: command, config, scons, version, or
+##     boost
 ### command: python command to use
 ### config: python-config command use
 ### scon: scons command to use
+### version: Python major version
+### boost: name of the python-boost library, without the file extension and
+###    without the initial "lib"
 ## writes output to stdout
 #
 arg=$1
+get_python_version() {
+    version_full=`${pycommand[command]} --version 2>&1 | awk '{print $2}'`
+    version_major=`echo $version_full | awk -F. '{print $1}'`
+    version_minor=`echo $version_full | awk -F. '{print $2}'`
+    version_subminor=`echo $version_full | awk -F. '{print $3}'`
+}
 #
 # get OS-related information
 #
@@ -52,31 +62,34 @@ then
     pycommand[command]=python
     pycommand[config]=python-config
     pycommand[scons]=scons
-    if [ $dist_version -le 31 ]
-    then
-	pycommand[version]=2
-    else
-	pycommand[version]=3
-    fi
+    get_python_version
+    pycommand[version]=$version_major
+    pycommand[boost]=boost_python
 elif [[ $dist_name == RedHat || $dist_name == CentOS ]]
 then
     if [ $dist_version -le 7 ]
     then
 	pycommand[command]=python
+	get_python_version
 	pycommand[config]=python-config
 	pycommand[scons]=scons
-	pycommand[version]=2
+	pycommand[boost]=boost_python
     else
 	pycommand[command]=python3
-	pycommand[config]=python3-config
-	pycommand[scons]=scons-3
-	pycommand[version]=3
+	get_python_version
+	pycommand[config]=python$version_major-config
+	pycommand[scons]=scons-$version_major
+	pycommand[boost]=boost_python$version_major
     fi
+    pycommand[version]=$version_major
 fi
 #
 # report the answer
 #
 case $arg in
+    boost)
+	echo ${pycommand[boost]}
+	;;
     command)
 	echo ${pycommand[command]}
 	;;
@@ -88,10 +101,15 @@ case $arg in
 	echo dist_name = $dist_name
 	echo dist_version = $dist_version
 	echo distribution = $distribution
+	echo version_full = $version_full
+	echo version_major = $version_major
+	echo version_minor = $version_minor
+	echo version_subminor = $version_subminor
 	echo python command = ${pycommand[command]}
 	echo config command = ${pycommand[config]}
 	echo scons command = ${pycommand[scons]}
 	echo version command = ${pycommand[version]}
+	echo boost command = ${pycommand[boost]}
 	;;
     scons)
 	echo ${pycommand[scons]}


### PR DESCRIPTION
- Numerous changes to allow builds on CentOS 8, Fedora 32, and Fedora 33.
- Depends on the Python package "futurize" to implement Python 2/3 compatible builds with scons.
- Uses new script python_chooser.sh to select correct Python components depending on the distribution.