### PR TITLE
add sciml to node names to check for CENTOS builds

### DIFF
--- a/osrelease.pl
+++ b/osrelease.pl
@@ -73,7 +73,8 @@ if ($uname eq 'Linux') {
 		    && $container_tag eq ""
 		    && ($nodename =~ /^farm/
 			|| $nodename =~ /^ifarm/
-			|| $nodename =~ /^qcd/)) {
+			|| $nodename =~ /^qcd/
+			|| $nodename =~ /^sciml/)) {
 		    @token = split(/\s+/, $release_string);
 		    @version = split(/\./, $token[3]);
 		    $version_minor = $version[1];


### PR DESCRIPTION
Change needed to find CENTOS7.7 minor version on new sciml nodes with GPU