### PR TITLE
Add -Dbuiltin_tbb=ON to cmake options, removes dependence on system-i…

### DIFF
--- a/Makefile_root_6_inc
+++ b/Makefile_root_6_inc
@@ -34,7 +34,7 @@ $(ROOTDIR)/.untar_done: $(TARFILE)
 
 $(ROOTDIR)/.cmake_done: $(ROOTDIR)/.untar_done
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) ; $(CMAKE) .. -DCMAKE_INSTALL_PREFIX=.. $(CMAKE_VERBOSE_OPTION) -Dgdml=ON -Droofit=ON -Dmysql=OFF -Ddavix=OFF
+	cd $(BUILD_DIR) ; $(CMAKE) .. -DCMAKE_INSTALL_PREFIX=.. $(CMAKE_VERBOSE_OPTION) -Dgdml=ON -Droofit=ON -Dmysql=OFF -Ddavix=OFF -Dbuiltin_tbb=ON
 	date > $@
 
 $(ROOTDIR)/.build_done: $(ROOTDIR)/.cmake_done


### PR DESCRIPTION
…nstalled package tbb-devel.