### PR TITLE
After Geant4 set-up, remove /usr/lib64 from LD_LIBRARY_PATH. Messes up

### DIFF
--- a/gluex_env.csh
+++ b/gluex_env.csh
@@ -49,7 +49,8 @@ if ( -e $G4ROOT) then
     if ( -f $g4setup) then
 	set g4dir=`dirname $g4setup`
 	source $g4setup $g4dir
-	unset g4dir
+	eval `delpath.pl -l /usr/lib64`
+	unset g4setup g4dir
     endif
     unset g4setup
 endif

--- a/gluex_env.sh
+++ b/gluex_env.sh
@@ -80,6 +80,7 @@ if [ -e "$G4ROOT" ]
     then
     g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.sh`
     if [ -f "$g4setup" ]; then source $g4setup; fi
+    eval `$BUILD_SCRIPTS/delpath.pl -b -l /usr/lib64`
     unset g4setup
 fi
 # amptools


### PR DESCRIPTION
use of alternate GCC versions.