### PR TITLE
Add a qt_version.mk file that keys off of the existence of

### DIFF
--- a/Makefile_hdgeant4
+++ b/Makefile_hdgeant4
@@ -31,6 +31,8 @@ PYTHON_CONFIG = $(shell $(BUILD_SCRIPTS)/python_chooser.sh config)
 PYTHON_BOOST = $(shell $(BUILD_SCRIPTS)/python_chooser.sh boost)
 PYTHON_LIB_OPTION = $(shell $(BUILD_SCRIPTS)/python_chooser.sh lib)
 
+include $(BUILD_SCRIPTS)/qt_version.mk # defines QT_VERSION
+
 all: force_rebuild_action $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml
 
 force_rebuild_action:
@@ -68,7 +70,7 @@ $(HDGEANT4_HOME)/.make_done: $(HDGEANT4_HOME)/.link_to_fixes_done
 	    then echo Geant4 setup not complete, sourcing geant4make.sh ; \
 	    . `find $(G4ROOT)/share/ -name geant4make.sh` ; \
 	fi ; \
-	make PYTHON_CONFIG=$(PYTHON_CONFIG) BOOST_PYTHON_LIB=$(PYTHON_BOOST) PYTHON_LIB_OPTION=$(PYTHON_LIB_OPTION) $(HDGEANT4_MAKE_OPTIONS) QT_VERSION=4
+	make PYTHON_CONFIG=$(PYTHON_CONFIG) BOOST_PYTHON_LIB=$(PYTHON_BOOST) PYTHON_LIB_OPTION=$(PYTHON_LIB_OPTION) $(HDGEANT4_MAKE_OPTIONS) QT_VERSION=$(QT_VERSION)
 	date > $@
 
 $(HDGEANT4_HOME)/hdgeant4_prereqs_version.xml: $(HDGEANT4_HOME)/.make_done

--- a/qt_version.mk
+++ b/qt_version.mk
@@ -1,0 +1,1 @@
+QT_VERSION := $(shell if [ -f  "/usr/lib64/libQt5Core.so" ]; then echo 5; else echo 4; fi)


### PR DESCRIPTION
/usr/lib64/libQt5Core.so to determine the version of Qt to use rather than the
hard-wired “4” for hdgeant4.