### PR TITLE
Remove halld_amp as a package needed for halld_sim. We are not there …

### DIFF
--- a/version_prereqs.pl
+++ b/version_prereqs.pl
@@ -36,7 +36,7 @@ eval $definitions;
 	    geant4 => [],
 	    ccdb => [],
 	    halld_recon => ['evio', 'cernlib', 'xerces-c', 'root', 'jana', 'hdds', 'ccdb', 'rcdb', 'sqlitecpp'],
-	    halld_sim => ['halld_recon', 'halld_amp'],
+	    halld_sim => ['halld_recon'],
 	    amptools => ['root'],
 	    photos => ['hepmc'],
 	    evtgen => ['photos', 'hepmc'],


### PR DESCRIPTION
…yet. This is generating warnings.