### PR TITLE
Remove default home defs 2

### DIFF
--- a/gluex_env.csh
+++ b/gluex_env.csh
@@ -12,30 +12,33 @@ if (! $?LD_LIBRARY_PATH) setenv LD_LIBRARY_PATH ''
 if (! $?PYTHONPATH) setenv PYTHONPATH ''
 set machine_type=`uname -m`
 # xerces-c++
-if (! $?XERCESCROOT) setenv XERCESCROOT $GLUEX_TOP/xerces-c/prod
-setenv XERCES_INCLUDE $XERCESCROOT/include
-echo $LD_LIBRARY_PATH | grep $XERCESCROOT/lib > /dev/null
-if ($status) setenv LD_LIBRARY_PATH  $XERCESCROOT/lib:$LD_LIBRARY_PATH
-# root
-if (! $?ROOTSYS) setenv ROOTSYS $GLUEX_TOP/root/prod
-echo $PATH | grep $ROOTSYS/bin > /dev/null
-if ($status) setenv PATH $ROOTSYS/bin:$PATH
-echo $LD_LIBRARY_PATH | grep $ROOTSYS/lib > /dev/null
-if ($status) setenv LD_LIBRARY_PATH  $ROOTSYS/lib:$LD_LIBRARY_PATH
-echo $PYTHONPATH | grep $ROOTSYS/lib > /dev/null
-if ($status) setenv PYTHONPATH $ROOTSYS/lib:$PYTHONPATH
-# cernlib
-if (! $?CERN ) setenv CERN $GLUEX_TOP/cernlib
-if (! $?CERN_LEVEL) then
-    if ($machine_type == 'x86_64') then
-        setenv CERN_LEVEL 2005
-    else
-	setenv CERN_LEVEL 2006
-    endif
+if ($?XERCESCROOT) then
+    setenv XERCES_INCLUDE $XERCESCROOT/include
+    echo $LD_LIBRARY_PATH | grep $XERCESCROOT/lib > /dev/null
+    if ($status) setenv LD_LIBRARY_PATH  $XERCESCROOT/lib:$LD_LIBRARY_PATH
 endif
-setenv CERN_ROOT $CERN/$CERN_LEVEL
-echo $PATH | grep $CERN_ROOT/bin > /dev/null
-if ($status) setenv PATH $CERN_ROOT/bin:$PATH
+# root
+if ($?ROOTSYS) then
+    echo $PATH | grep $ROOTSYS/bin > /dev/null
+    if ($status) setenv PATH $ROOTSYS/bin:$PATH
+    echo $LD_LIBRARY_PATH | grep $ROOTSYS/lib > /dev/null
+    if ($status) setenv LD_LIBRARY_PATH  $ROOTSYS/lib:$LD_LIBRARY_PATH
+    echo $PYTHONPATH | grep $ROOTSYS/lib > /dev/null
+    if ($status) setenv PYTHONPATH $ROOTSYS/lib:$PYTHONPATH
+endif
+# cernlib
+if ($?CERN ) then
+    if (! $?CERN_LEVEL) then
+	if ($machine_type == 'x86_64') then
+	    setenv CERN_LEVEL 2005
+	else
+	    setenv CERN_LEVEL 2006
+	endif
+    endif
+    setenv CERN_ROOT $CERN/$CERN_LEVEL
+    echo $PATH | grep $CERN_ROOT/bin > /dev/null
+    if ($status) setenv PATH $CERN_ROOT/bin:$PATH
+endif
 ## clhep
 #if (! $?CLHEP) setenv CLHEP $GLUEX_TOP/clhep/prod
 #setenv CLHEP_INCLUDE $CLHEP/include
@@ -43,46 +46,50 @@ if ($status) setenv PATH $CERN_ROOT/bin:$PATH
 #echo $LD_LIBRARY_PATH | grep $CLHEP_LIB > /dev/null
 #if ($status) setenv LD_LIBRARY_PATH ${CLHEP_LIB}:${LD_LIBRARY_PATH}
 # Geant4
-if (! $?G4ROOT) setenv G4ROOT $GLUEX_TOP/geant4/prod
-if ( -e $G4ROOT) then
-    set g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.csh`
-    if ( -f $g4setup) then
-	set g4dir=`dirname $g4setup`
-	source $g4setup $g4dir
-	eval `$BUILD_SCRIPTS/delpath.pl -l /usr/lib64`
-	unset g4setup g4dir
+if ($?G4ROOT) then
+    if ( -e $G4ROOT) then
+	set g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.csh`
+	if ( -f $g4setup) then
+	    set g4dir=`dirname $g4setup`
+	    source $g4setup $g4dir
+	    eval `$BUILD_SCRIPTS/delpath.pl -l /usr/lib64`
+	    unset g4setup g4dir
+	endif
+	unset g4setup
     endif
-    unset g4setup
 endif
 # amptools
 if ($?AMPTOOLS_HOME) then
-setenv AMPTOOLS $AMPTOOLS_HOME/AmpTools
-setenv AMPPLOTTER $AMPTOOLS_HOME/AmpPlotter
+    setenv AMPTOOLS $AMPTOOLS_HOME/AmpTools
+    setenv AMPPLOTTER $AMPTOOLS_HOME/AmpPlotter
 endif
 # ccdb
-if (! $?CCDB_HOME) setenv CCDB_HOME $GLUEX_TOP/ccdb/prod
-source $BUILD_SCRIPTS/ccdb_env.csh
-if (! $?CCDB_USER) then
-    if ($?USER) then
-	setenv CCDB_USER $USER
+if ($?CCDB_HOME) then
+    source $BUILD_SCRIPTS/ccdb_env.csh
+    if (! $?CCDB_USER) then
+	if ($?USER) then
+	    setenv CCDB_USER $USER
+	endif
     endif
+    if (! $?CCDB_CONNECTION) setenv CCDB_CONNECTION mysql://ccdb_user@hallddb.jlab.org/ccdb
 endif
-if (! $?CCDB_CONNECTION) setenv CCDB_CONNECTION mysql://ccdb_user@hallddb.jlab.org/ccdb
 # rcdb
-if (! $?RCDB_HOME) setenv RCDB_HOME $GLUEX_TOP/rcdb/prod
-source $BUILD_SCRIPTS/rcdb_env.csh
-if (! $?RCDB_CONNECTION) setenv RCDB_CONNECTION mysql://rcdb@hallddb.jlab.org/rcdb
+if ($?RCDB_HOME) then
+    source $BUILD_SCRIPTS/rcdb_env.csh
+    if (! $?RCDB_CONNECTION) setenv RCDB_CONNECTION mysql://rcdb@hallddb.jlab.org/rcdb
+endif
 # jana
-if (! $?JANA_HOME) setenv JANA_HOME $GLUEX_TOP/jana/prod/$BMS_OSNAME
-if (! $?JANA_CALIB_URL) setenv JANA_CALIB_URL $CCDB_CONNECTION
-echo $PATH | grep $JANA_HOME/bin > /dev/null
-if ($status) setenv PATH $JANA_HOME/bin:$PATH
+if ($?JANA_HOME) then
+    if (! $?JANA_CALIB_URL) setenv JANA_CALIB_URL $CCDB_CONNECTION
+    echo $PATH | grep $JANA_HOME/bin > /dev/null
+    if ($status) setenv PATH $JANA_HOME/bin:$PATH
+endif
 # EVIO
-if (! $?EVIOROOT) setenv EVIOROOT $GLUEX_TOP/evio/prod/`uname -s`-`uname -m`
-echo $LD_LIBRARY_PATH | grep $EVIOROOT/lib > /dev/null
-if ($status) setenv LD_LIBRARY_PATH  $EVIOROOT/lib:$LD_LIBRARY_PATH
+if ($?EVIOROOT) then
+    echo $LD_LIBRARY_PATH | grep $EVIOROOT/lib > /dev/null
+    if ($status) setenv LD_LIBRARY_PATH  $EVIOROOT/lib:$LD_LIBRARY_PATH
+endif
 # hdds
-if (! $?HDDS_HOME) setenv HDDS_HOME $GLUEX_TOP/hdds/prod
 setenv JANA_GEOMETRY_URL ccdb:///GEOMETRY/main_HDDS.xml
 # halld
 if ($?HALLD_HOME) then
@@ -126,14 +133,14 @@ if ($?HDGEANT4_HOME) then
     if ($status) setenv PYTHONPATH $HDGEANT4_HOME/g4py:$PYTHONPATH
 endif
 #
-# hd_utilities
+# hd_utilities: nothing to do for hd_utilities
 #
-if (! $?HD_UTILITIES_HOME) setenv HD_UTILITIES_HOME $GLUEX_TOP/hd_utilities/prod
 #
 # gluex_MCwrapper
 #
-if (! $?MCWRAPPER_CENTRAL) setenv MCWRAPPER_CENTRAL $HD_UTILITIES_HOME/MCwrapper
-setenv PATH ${MCWRAPPER_CENTRAL}:$PATH
+if ($?MCWRAPPER_CENTRAL) then
+    setenv PATH ${MCWRAPPER_CENTRAL}:$PATH
+endif
 #
 # gluex_root_analysis
 #
@@ -141,9 +148,8 @@ if ($?ROOT_ANALYSIS_HOME) then
     if (-e $ROOT_ANALYSIS_HOME) source $ROOT_ANALYSIS_HOME/env_analysis.csh
 endif
 #
-# sqlitecpp
+# sqlitecpp: nothing to do for SQLiteCpp
 #
-if (! $?SQLITECPP_HOME) setenv SQLITECPP_HOME $GLUEX_TOP/sqlitecpp/prod
 #
 # hepmc
 #
@@ -207,7 +213,7 @@ if ($gluex_env_verbose) then
 endif
 # check consistency of environment
 set check_versions="true"
-if($?BUILD_SCRIPTS_CONSISTENCY_CHECK) then
+if ($?BUILD_SCRIPTS_CONSISTENCY_CHECK) then
     if ($BUILD_SCRIPTS_CONSISTENCY_CHECK == "false") then
 	set check_versions="false" 
     endif

--- a/gluex_env.sh
+++ b/gluex_env.sh
@@ -35,37 +35,48 @@ then export BMS_OSNAME=`$BUILD_SCRIPTS/osrelease.pl`
 fi
 if [ -z "$LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH=''; fi
 # xerces-c++
-if [ -z "$XERCESCROOT" ]; then export XERCESCROOT=$GLUEX_TOP/xerces-c/prod; fi
-export XERCES_INCLUDE=$XERCESCROOT/include
-if [ `echo $LD_LIBRARY_PATH | grep -c $XERCESCROOT/lib` -eq 0 ]
+if [ -n "$XERCESCROOT" ]
+then
+    export XERCES_INCLUDE=$XERCESCROOT/include
+    if [ `echo $LD_LIBRARY_PATH | grep -c $XERCESCROOT/lib` -eq 0 ]
     then export LD_LIBRARY_PATH=$XERCESCROOT/lib:$LD_LIBRARY_PATH
+    fi
 fi
 # root
-if [ -z "$ROOTSYS" ]; then export ROOTSYS=$GLUEX_TOP/root/prod; fi
-if [ `echo $PATH | grep -c $ROOTSYS/bin` -eq 0 ]
-    then export PATH=$ROOTSYS/bin:$PATH
-fi
-if [ `echo $LD_LIBRARY_PATH | grep -c $ROOTSYS/lib` -eq 0 ]
-    then export LD_LIBRARY_PATH=$ROOTSYS/lib:$LD_LIBRARY_PATH
-fi
-if [ `echo $PYTHONPATH | grep -c $ROOTSYS/lib` -eq 0 ]
-    then export PYTHONPATH=$ROOTSYS/lib:$PYTHONPATH
+if [ -n "$ROOTSYS" ]
+then
+    if [ `echo $PATH | grep -c $ROOTSYS/bin` -eq 0 ]
+    then
+	export PATH=$ROOTSYS/bin:$PATH
+    fi
+    if [ `echo $LD_LIBRARY_PATH | grep -c $ROOTSYS/lib` -eq 0 ]
+    then
+	export LD_LIBRARY_PATH=$ROOTSYS/lib:$LD_LIBRARY_PATH
+    fi
+    if [ `echo $PYTHONPATH | grep -c $ROOTSYS/lib` -eq 0 ]
+    then
+	export PYTHONPATH=$ROOTSYS/lib:$PYTHONPATH
+    fi
 fi
 # cernlib
-if [ -z "$CERN" ]; then export CERN=$GLUEX_TOP/cernlib; fi
-if [ -z "$CERN_LEVEL" ]; then 					#We don't have CERN_LEVEL
-	if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-		#on 64 bits 2005 cernlib is provided
-		export CERN_LEVEL=2005; 
+if [ -n "$CERN" ]
+then
+    if [ -z "$CERN_LEVEL" ]
+    then 					#We don't have CERN_LEVEL
+	if [ ${MACHINE_TYPE} == 'x86_64' ]
+	then
+	    #on 64 bits 2005 cernlib is provided
+	    export CERN_LEVEL=2005; 
 	else
-		#on 32-bit 2006 cernlib is provided
-		export CERN_LEVEL=2006;
+	    #on 32-bit 2006 cernlib is provided
+	    export CERN_LEVEL=2006;
 	fi
-fi
-
-export CERN_ROOT=$CERN/$CERN_LEVEL
-if [ `echo $PATH | grep -c $CERN_ROOT/bin` -eq 0 ]
-    then export PATH=$CERN_ROOT/bin:$PATH
+    fi
+    export CERN_ROOT=$CERN/$CERN_LEVEL
+    if [ `echo $PATH | grep -c $CERN_ROOT/bin` -eq 0 ]
+    then
+	export PATH=$CERN_ROOT/bin:$PATH
+    fi
 fi
 ## clhep
 #if [ -z "$CLHEP" ]; then export CLHEP=$GLUEX_TOP/clhep/prod; fi
@@ -75,31 +86,50 @@ fi
 #    then export LD_LIBRARY_PATH=${CLHEP_LIB}:${LD_LIBRARY_PATH}
 #fi
 # Geant4
-if [ -z "$G4ROOT" ]; then export G4ROOT=$GLUEX_TOP/geant4/prod; fi
-if [ -e "$G4ROOT" ]
+if [ -n "$G4ROOT" ]
+then
+    if [ -e "$G4ROOT" ]
     then
-    g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.sh`
-    if [ -f "$g4setup" ]; then source $g4setup; fi
-    eval `$BUILD_SCRIPTS/delpath.pl -b -l /usr/lib64`
-    unset g4setup
+	g4setup=`find $G4ROOT/share/ -maxdepth 3 -name geant4make.sh`
+	if [ -f "$g4setup" ]
+	then
+	    source $g4setup
+	fi
+	eval `$BUILD_SCRIPTS/delpath.pl -b -l /usr/lib64`
+	unset g4setup
+    fi
 fi
 # amptools
-if [ -n "$AMPTOOLS_HOME" ]; then
+if [ -n "$AMPTOOLS_HOME" ]
+then
     export AMPTOOLS=$AMPTOOLS_HOME/AmpTools
     export AMPPLOTTER=$AMPTOOLS_HOME/AmpPlotter
 fi
 # ccdb
-if [ -z "$CCDB_HOME" ]; then export CCDB_HOME=$GLUEX_TOP/ccdb/prod; fi
-. $BUILD_SCRIPTS/ccdb_env.sh
-if [ -z "$CCDB_USER" ]
+if [ -n "$CCDB_HOME" ]
+then
+    . $BUILD_SCRIPTS/ccdb_env.sh
+    if [ -z "$CCDB_USER" ]
     then
-    if [ -n "${USER:-}" ]; then export CCDB_USER=$USER; fi
+	if [ -n "${USER:-}" ]
+	then
+	    export CCDB_USER=$USER
+	fi
+    fi
+    if [ -z "$CCDB_CONNECTION" ]
+    then
+	export CCDB_CONNECTION=mysql://ccdb_user@hallddb.jlab.org/ccdb
+    fi
 fi
-if [ -z "$CCDB_CONNECTION" ]; then export CCDB_CONNECTION=mysql://ccdb_user@hallddb.jlab.org/ccdb; fi
 # rcdb
-if [ -z "$RCDB_HOME" ]; then export RCDB_HOME=$GLUEX_TOP/rcdb/prod; fi
-. $BUILD_SCRIPTS/rcdb_env.sh
-if [ -z "$RCDB_CONNECTION" ]; then export RCDB_CONNECTION=mysql://rcdb@hallddb.jlab.org/rcdb; fi
+if [ -n "$RCDB_HOME" ]
+then
+    . $BUILD_SCRIPTS/rcdb_env.sh
+    if [ -z "$RCDB_CONNECTION" ]
+    then
+	export RCDB_CONNECTION=mysql://rcdb@hallddb.jlab.org/rcdb
+    fi
+fi
 # jana
 if [ -z "$JANA_HOME" ]; then export JANA_HOME=$GLUEX_TOP/jana/prod/$BMS_OSNAME; fi
 if [ -z "$JANA_CALIB_URL" ]

--- a/gluex_env.sh
+++ b/gluex_env.sh
@@ -131,42 +131,51 @@ then
     fi
 fi
 # jana
-if [ -z "$JANA_HOME" ]; then export JANA_HOME=$GLUEX_TOP/jana/prod/$BMS_OSNAME; fi
-if [ -z "$JANA_CALIB_URL" ]
-    then export JANA_CALIB_URL=$CCDB_CONNECTION
-fi
-if [ `echo $PATH | grep -c $JANA_HOME/bin` -eq 0 ]
-    then export PATH=$JANA_HOME/bin:$PATH
+if [ -n "$JANA_HOME" ]
+then
+    if [ -z "$JANA_CALIB_URL" ]
+    then
+	export JANA_CALIB_URL=$CCDB_CONNECTION
+    fi
+    if [ `echo $PATH | grep -c $JANA_HOME/bin` -eq 0 ]
+    then
+	export PATH=$JANA_HOME/bin:$PATH
+    fi
 fi
 # EVIO
-if [ -z "$EVIOROOT" ]; then export EVIOROOT=$GLUEX_TOP/evio/prod/`uname -s`-`uname -m`; fi
-if [ `echo $LD_LIBRARY_PATH | grep -c $EVIOROOT/lib` -eq 0 ]
-    then export LD_LIBRARY_PATH=$EVIOROOT/lib:$LD_LIBRARY_PATH
+if [ -n "$EVIOROOT" ]
+then
+    if [ `echo $LD_LIBRARY_PATH | grep -c $EVIOROOT/lib` -eq 0 ]
+    then
+	export LD_LIBRARY_PATH=$EVIOROOT/lib:$LD_LIBRARY_PATH
+    fi
 fi
 # hdds
-if [ -z "$HDDS_HOME" ]; then export HDDS_HOME=$GLUEX_TOP/hdds/prod; fi
 export JANA_GEOMETRY_URL=ccdb:///GEOMETRY/main_HDDS.xml
 # sim-recon
 if [ -n "$HALLD_HOME" ]
-    then
+then
     if [ `echo $PATH | grep -c $HALLD_HOME/$BMS_OSNAME/bin` -eq 0 ]
-        then export PATH=$HALLD_HOME/${BMS_OSNAME}/bin:$PATH
+    then
+	export PATH=$HALLD_HOME/${BMS_OSNAME}/bin:$PATH
     fi
     export PYTHONPATH=$HALLD_HOME/$BMS_OSNAME/python2:$PYTHONPATH
 fi
 # halld_recon
 if [ -n "$HALLD_RECON_HOME" ]
-    then
+then
     if [ `echo $PATH | grep -c $HALLD_RECON_HOME/$BMS_OSNAME/bin` -eq 0 ]
-        then export PATH=$HALLD_RECON_HOME/${BMS_OSNAME}/bin:$PATH
+    then
+	export PATH=$HALLD_RECON_HOME/${BMS_OSNAME}/bin:$PATH
     fi
     export PYTHONPATH=$HALLD_RECON_HOME/$BMS_OSNAME/python2:$PYTHONPATH
 fi
 # halld_sim
 if [ -n "$HALLD_SIM_HOME" ]
-    then
+then
     if [ `echo $PATH | grep -c $HALLD_SIM_HOME/$BMS_OSNAME/bin` -eq 0 ]
-        then export PATH=$HALLD_SIM_HOME/${BMS_OSNAME}/bin:$PATH
+    then
+	export PATH=$HALLD_SIM_HOME/${BMS_OSNAME}/bin:$PATH
     fi
 fi
 # halld_my
@@ -199,14 +208,15 @@ if [ -n "$HDGEANT4_HOME" ]; then
     fi
 fi
 #
-# hd_utilities
+# hd_utilities: nothing to do for hd_utilities
 #
-if [ -z "$HD_UTILITIES_HOME" ]; then export HD_UTILITIES_HOME=$GLUEX_TOP/hd_utilities/prod; fi
 #
 # gluex_MCwrapper
 #
-if [ -z "$MCWRAPPER_CENTRAL" ]; then export MCWRAPPER_CENTRAL=$HD_UTILITIES_HOME/MCwrapper; fi
-export PATH=${MCWRAPPER_CENTRAL}:$PATH
+if [ -n "$MCWRAPPER_CENTRAL" ]
+then
+    export PATH=${MCWRAPPER_CENTRAL}:$PATH
+fi
 #
 # gluex_root_analysis
 #
@@ -214,25 +224,29 @@ if [ -n "$ROOT_ANALYSIS_HOME" ]; then
     if [ -e "$ROOT_ANALYSIS_HOME" ]; then source $ROOT_ANALYSIS_HOME/env_analysis.sh ; fi
 fi
 #
-# SQLiteCpp
+# SQLiteCpp: nothing to do for SQLiteCpp
 #
-if [ -z "$SQLITECPP_HOME" ]; then export SQLITECPP_HOME=$GLUEX_TOP/sqlitecpp/prod; fi
+#
 # hepmc
 if [ -n "$HEPMCDIR" ]; then
     if [ `echo $LD_LIBRARY_PATH | grep -c $HEPMCDIR/lib` -eq 0 ]
-    then export LD_LIBRARY_PATH=$HEPMCDIR/lib:$LD_LIBRARY_PATH
+    then
+	export LD_LIBRARY_PATH=$HEPMCDIR/lib:$LD_LIBRARY_PATH
     fi
 fi
 # photos
 if [ -n "$PHOTOSDIR" ]; then
     if [ `echo $LD_LIBRARY_PATH | grep -c $PHOTOSDIR/lib` -eq 0 ]
-    then export LD_LIBRARY_PATH=$PHOTOSDIR/lib:$LD_LIBRARY_PATH
+    then
+	export LD_LIBRARY_PATH=$PHOTOSDIR/lib:$LD_LIBRARY_PATH
     fi
 fi
 # evtgen
-if [ -n "$EVTGENDIR" ]; then
+if [ -n "$EVTGENDIR" ]
+then
     if [ `echo $LD_LIBRARY_PATH | grep -c $EVTGENDIR/lib` -eq 0 ]
-    then export LD_LIBRARY_PATH=$EVTGENDIR/lib:$LD_LIBRARY_PATH
+    then
+	export LD_LIBRARY_PATH=$EVTGENDIR/lib:$LD_LIBRARY_PATH
     fi
 fi
 #
@@ -283,5 +297,6 @@ if [ $gluex_env_verbose -eq 1 ]
 fi
 # check consistency of environment
 if [ "$BUILD_SCRIPTS_CONSISTENCY_CHECK" != "false" ]
-then $BUILD_SCRIPTS/version_check.pl
+then
+    $BUILD_SCRIPTS/version_check.pl
 fi

--- a/tests/clean/test_clean.sh
+++ b/tests/clean/test_clean.sh
@@ -2,7 +2,7 @@
 rm -f before_setup.tmp after_setup.tmp after_clean.tmp
 printenv | sort > before_setup.tmp
 echo source test.sh
-source test.sh
+source ./test.sh
 printenv | sort > after_setup.tmp
 echo source gluex_env_clean.sh
 source $BUILD_SCRIPTS/gluex_env_clean.sh


### PR DESCRIPTION
The original Build Scripts would define a home directory for every package if one was not found in the environment. These were the "prod" directories. This behavior was removed for some of the GlueX-specific packages some time ago. This pull request removes that behavior for all packages.

The new paradigm is that package-specific set-up steps are only performed when said packages are defined, usually via a version set file.
