### PR TITLE
add no-check-certificate to wget

### DIFF
--- a/Makefile_lapack
+++ b/Makefile_lapack
@@ -47,7 +47,7 @@ $(LAPACKROOT)/.untar_done: $(TARFILE)
 	date > $@
 
 $(TARFILE):
-	wget --no-verbose http://www.netlib.org/lapack/$(TARFILE)
+	wget --no-check-certificate --no-verbose http://www.netlib.org/lapack/$(TARFILE)
 
 show_env:
 	@echo MAJOR = $(MAJOR)


### PR DESCRIPTION
For some reason a container version of CentOS 7 is failing on a certificate check.