### PR TITLE
table version != table versionSet

### DIFF
--- a/vsdb/tables.sql
+++ b/vsdb/tables.sql
@@ -59,7 +59,6 @@ CREATE TABLE `version` (
   `word_length` varchar(64) DEFAULT NULL,
   `debug_level` int(11) DEFAULT NULL,
   `onOasis` tinyint(1) DEFAULT 0,
-  `OS_ID` int DEFAULT 1,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -97,6 +96,7 @@ CREATE TABLE `versionSet` (
   `description` varchar(256) DEFAULT NULL,
   `fileExists` tinyint(1) DEFAULT NULL,
   `onOasis` tinyint(1) DEFAULT 0,
+  `OS_ID` int DEFAULT 1,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
this movers the column to the proper table.  The other table will be corrected when BScrawler is first run